### PR TITLE
Add Receiver::disconnect

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -788,6 +788,18 @@ impl<T> Receiver<T> {
     pub fn try_iter(&self) -> TryIter<T> {
         TryIter { rx: self }
     }
+
+    /// Closes the receiver, causing subsequent sends to fail.
+    ///
+    /// This prevents any further messages from being sent on the channel while still allowing the
+    /// receiver to drain existing buffered messages.
+    pub fn close(&self) {
+        match self.0.flavor {
+            Flavor::Array(ref chan) => chan.close(),
+            Flavor::List(ref chan) => chan.close(),
+            Flavor::Zero(ref chan) => chan.close(),
+        };
+    }
 }
 
 impl<T> Drop for Receiver<T> {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -387,7 +387,7 @@ impl<T> Sender<T> {
         }
     }
 
-    /// Returns `true` if the channel is disconnected (i.e. there are no receivers).
+    /// Returns `true` if the channel is disconnected.
     ///
     /// # Examples
     ///
@@ -406,6 +406,36 @@ impl<T> Sender<T> {
             Flavor::Array(ref chan) => chan.is_disconnected(),
             Flavor::List(ref chan) => chan.is_disconnected(),
             Flavor::Zero(ref chan) => chan.is_disconnected(),
+        }
+    }
+
+    /// Disconnects the channel.
+    ///
+    /// Returns `true` if this call disconnected the channel and `false` if it was already
+    /// disconnected.
+    ///
+    /// Disconnection prevents any further messages from being sent into the channel, while still
+    /// allowing the receiver to drain any existing buffered messages.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::unbounded;
+    ///
+    /// let (tx, rx) = unbounded::<i32>();
+    /// tx.send(1);
+    /// tx.send(2);
+    ///
+    /// rx.disconnect();
+    /// assert_eq!(rx.recv(), Ok(1));
+    /// assert_eq!(rx.recv(), Ok(2));
+    /// assert!(rx.recv().is_err());
+    /// ```
+    pub fn disconnect(&self) -> bool {
+        match self.0.flavor {
+            Flavor::Array(ref chan) => chan.disconnect(),
+            Flavor::List(ref chan) => chan.disconnect(),
+            Flavor::Zero(ref chan) => chan.disconnect(),
         }
     }
 }
@@ -715,7 +745,7 @@ impl<T> Receiver<T> {
         }
     }
 
-    /// Returns `true` if the channel is disconnected (i.e. there are no senders). TODO: these parens
+    /// Returns `true` if the channel is disconnected.
     ///
     /// # Examples
     ///
@@ -795,16 +825,34 @@ impl<T> Receiver<T> {
         TryIter { rx: self }
     }
 
-    /// Disconnects the receiver, causing subsequent sends to fail.
+    /// Disconnects the channel.
     ///
-    /// This prevents any further messages from being sent on the channel while still allowing the
-    /// receiver to drain existing buffered messages.
-    pub fn disconnect(&self) {
+    /// Returns `true` if this call disconnected the channel and `false` if it was already
+    /// disconnected.
+    ///
+    /// Disconnection prevents any further messages from being sent into the channel, while still
+    /// allowing the receiver to drain any existing buffered messages.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crossbeam_channel::unbounded;
+    ///
+    /// let (tx, rx) = unbounded::<i32>();
+    /// tx.send(1);
+    /// tx.send(2);
+    /// tx.disconnect();
+    ///
+    /// assert_eq!(rx.recv(), Ok(1));
+    /// assert_eq!(rx.recv(), Ok(2));
+    /// assert!(rx.recv().is_err());
+    /// ```
+    pub fn disconnect(&self) -> bool {
         match self.0.flavor {
             Flavor::Array(ref chan) => chan.disconnect(),
             Flavor::List(ref chan) => chan.disconnect(),
             Flavor::Zero(ref chan) => chan.disconnect(),
-        };
+        }
     }
 }
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -111,13 +111,13 @@ impl<T> fmt::Debug for SendError<T> {
 
 impl<T> fmt::Display for SendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "sending on a closed channel".fmt(f)
+        "sending on a disconnected channel".fmt(f)
     }
 }
 
 impl<T: Send> error::Error for SendError<T> {
     fn description(&self) -> &str {
-        "sending on a closed channel"
+        "sending on a disconnected channel"
     }
 
     fn cause(&self) -> Option<&error::Error> {
@@ -158,7 +158,7 @@ impl<T> fmt::Display for TrySendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TrySendError::Full(..) => "sending on a full channel".fmt(f),
-            TrySendError::Disconnected(..) => "sending on a closed channel".fmt(f),
+            TrySendError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
         }
     }
 }
@@ -167,7 +167,7 @@ impl<T: Send> error::Error for TrySendError<T> {
     fn description(&self) -> &str {
         match *self {
             TrySendError::Full(..) => "sending on a full channel",
-            TrySendError::Disconnected(..) => "sending on a closed channel",
+            TrySendError::Disconnected(..) => "sending on a disconnected channel",
         }
     }
 
@@ -216,14 +216,14 @@ impl<T> fmt::Display for SendTimeoutError<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SendTimeoutError::Timeout(..) => "timed out waiting on channel".fmt(f),
-            SendTimeoutError::Disconnected(..) => "sending on a closed channel".fmt(f),
+            SendTimeoutError::Disconnected(..) => "sending on a disconnected channel".fmt(f),
         }
     }
 }
 
 impl<T: Send> error::Error for SendTimeoutError<T> {
     fn description(&self) -> &str {
-        "sending on a closed channel"
+        "sending on an empty and disconnected channel"
     }
 
     fn cause(&self) -> Option<&error::Error> {
@@ -311,13 +311,13 @@ impl<T> SelectSendError<T> {
 
 impl fmt::Display for RecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "receiving on a closed channel".fmt(f)
+        "receiving on an empty and disconnected channel".fmt(f)
     }
 }
 
 impl error::Error for RecvError {
     fn description(&self) -> &str {
-        "receiving on a closed channel"
+        "receiving on an empty and disconnected channel"
     }
 
     fn cause(&self) -> Option<&error::Error> {
@@ -329,7 +329,7 @@ impl fmt::Display for TryRecvError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TryRecvError::Empty => "receiving on an empty channel".fmt(f),
-            TryRecvError::Disconnected => "receiving on a closed channel".fmt(f),
+            TryRecvError::Disconnected => "receiving on an empty and disconnected channel".fmt(f),
         }
     }
 }
@@ -338,7 +338,7 @@ impl error::Error for TryRecvError {
     fn description(&self) -> &str {
         match *self {
             TryRecvError::Empty => "receiving on an empty channel",
-            TryRecvError::Disconnected => "receiving on a closed channel",
+            TryRecvError::Disconnected => "receiving on an empty and disconnected channel",
         }
     }
 
@@ -359,7 +359,7 @@ impl fmt::Display for RecvTimeoutError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             RecvTimeoutError::Timeout => "timed out waiting on channel".fmt(f),
-            RecvTimeoutError::Disconnected => "channel is empty and sending half is closed".fmt(f),
+            RecvTimeoutError::Disconnected => "channel is empty and disconnected".fmt(f),
         }
     }
 }
@@ -368,7 +368,7 @@ impl error::Error for RecvTimeoutError {
     fn description(&self) -> &str {
         match *self {
             RecvTimeoutError::Timeout => "timed out waiting on channel",
-            RecvTimeoutError::Disconnected => "channel is empty and sending half is closed",
+            RecvTimeoutError::Disconnected => "channel is empty and sending half is Disconnected",
         }
     }
 

--- a/src/flavors/array.rs
+++ b/src/flavors/array.rs
@@ -6,7 +6,7 @@ use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 use std::mem;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::{Relaxed, Release, SeqCst};
 use std::time::Instant;
 
@@ -18,17 +18,35 @@ use select::CaseId;
 use select::handle;
 use utils::Backoff;
 
-/// An entry in the queue.
+/// An entry in the channel.
 ///
-/// Entries are empty on even laps and hold values on odd laps.
+/// Entries are empty on even laps and hold messages on odd laps.
 struct Entry<T> {
     /// The current lap.
     ///
     /// Entries are ready for writing on even laps and ready for reading on odd laps.
     lap: AtomicUsize,
 
-    /// The value in this entry.
-    value: UnsafeCell<T>,
+    /// The message in this entry.
+    msg: UnsafeCell<T>,
+}
+
+/// The list of possible error outcomes for the `push` operation.
+enum PushError<T> {
+    /// The channel is full.
+    Full(T),
+
+    /// The channel is disconnected.
+    Disconnected(T),
+}
+
+/// The list of possible error outcomes for the `pop` operation.
+enum PopError {
+    /// The channel is empty.
+    Empty,
+
+    /// The channel is disconnected.
+    Disconnected,
 }
 
 /// An array-based channel with fixed capacity.
@@ -38,29 +56,29 @@ struct Entry<T> {
 /// * http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
 /// * https://docs.google.com/document/d/1yIAYmbvL3JxOKOjuCyon7JhW4cSv1wy5hC0ApeGMV9s/pub
 pub struct Channel<T> {
-    /// Head of the queue (the next index to read from).
+    /// Head of the channel (the next index to read from).
     ///
-    /// The lower `log2(power)` bits hold the index into the buffer, and the upper bits hold the
-    /// current lap, which is always odd for `head`.
+    /// Bits lower than the mark bit represent the index, while the upper bits represent the lap.
+    /// The mark bit is always zero.
     head: CachePadded<AtomicUsize>,
 
-    /// Tail of the queue (the next index to write to).
+    /// Tail of the channel (the next index to write to).
     ///
-    /// The lower `log2(power)` bits hold the index into the buffer, and the upper bits hold the
-    /// current lap, which is always even for `tail`.
+    /// Bits lower than the mark bit represent the index, while the upper bits represent the lap.
+    /// If the mark bit is set, that means the channel is disconnected and the tail cannot move
+    /// forward any further.
     tail: CachePadded<AtomicUsize>,
 
-    /// Buffer holding entries in the queue.
+    /// Buffer holding entries in the channel.
     buffer: *mut Entry<T>,
 
     /// Channel capacity.
     cap: usize,
 
-    /// The next power of two greater than or equal to the capacity.
-    power: usize,
-
-    /// Equals `true` if the channel is disconnected.
-    is_disconnected: AtomicBool,
+    /// The mark bit.
+    ///
+    /// If the mark bit in the tail is set, that indicates the channel is disconnected.
+    mark_bit: usize,
 
     /// Senders waiting on full channel.
     senders: Monitor,
@@ -77,13 +95,14 @@ impl<T> Channel<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the capacity is zero.
+    /// Panics if the capacity is not in the range `1 .. usize::max_value() / (1 << 3)`.
     pub fn with_capacity(cap: usize) -> Self {
         assert!(cap > 0, "capacity must be positive");
 
-        // Make sure there are at least two most significant bits to encode laps. If this limit is
-        // hit, the buffer is most likely too large to allocate anyway.
-        let cap_limit = usize::max_value() / 4;
+        // Make sure there are at least two most significant bits to encode laps, plus one more bit
+        // for marking the tail to indicate that the channel is disconnected. If we can't reserve
+        // three bits, then panic. In that case, the buffer is likely too large to allocate anyway.
+        let cap_limit = usize::max_value() / (1 << 3);
         assert!(
             cap <= cap_limit,
             "channel capacity is too large: {} > {}",
@@ -107,19 +126,20 @@ impl<T> Channel<T> {
             }
         }
 
-        // Head is initialized with `power` (lap 1, index 0).
-        // Tail is initialized with 0 (lap 0, index 0).
-        let power = cap.next_power_of_two();
-        let head = power;
+        // The mark bit is the smallest power of two greater than or equal to `cap`.
+        let mark_bit = cap.next_power_of_two();
+
+        // Head is initialized with (lap: 1, mark: 0, index: 0).
+        // Tail is initialized with (lap: 0, mark: 0, index: 0).
+        let head = mark_bit << 1;
         let tail = 0;
 
         Channel {
             buffer,
             cap,
-            power,
+            mark_bit,
             head: CachePadded::new(AtomicUsize::new(head)),
             tail: CachePadded::new(AtomicUsize::new(tail)),
-            is_disconnected: AtomicBool::new(false),
             senders: Monitor::new(),
             receivers: Monitor::new(),
             _marker: PhantomData,
@@ -136,20 +156,30 @@ impl<T> Channel<T> {
         &*self.buffer.offset(index as isize)
     }
 
-    /// Attempts to push `value` into the queue.
+    /// Attempts to push `msg` into the channel.
     ///
-    /// Returns `None` on success, and `Some(value)` if the queue is full.
-    fn push(&self, value: T, backoff: &mut Backoff) -> Option<T> {
+    /// Returns `None` on success, and `Some(msg)` if the channel is full.
+    fn push(&self, msg: T, backoff: &mut Backoff) -> Result<(), PushError<T>> {
+        let one_lap = self.mark_bit << 1;
+        let index_bits = self.mark_bit - 1;
+        let lap_bits = !(one_lap - 1);
+
         loop {
             // Load the tail.
             let tail = self.tail.load(SeqCst);
-            let index = tail & (self.power - 1);
-            let lap = tail & !(self.power - 1);
+
+            // If the tail is marked, the channel is disconnected.
+            if tail & self.mark_bit != 0 {
+                return Err(PushError::Disconnected(msg));
+            }
+
+            let index = tail & index_bits;
+            let lap = tail & lap_bits;
 
             // Inspect the corresponding entry.
             let entry = unsafe { self.entry_at(index) };
             let elap = entry.lap.load(SeqCst);
-            let next_elap = elap.wrapping_add(self.power);
+            let next_elap = elap.wrapping_add(one_lap);
 
             // If the laps of the tail and the entry match, we may attempt to push.
             if lap == elap {
@@ -158,7 +188,7 @@ impl<T> Channel<T> {
                     tail + 1
                 } else {
                     // Two laps forward; index wraps around to zero.
-                    lap.wrapping_add(self.power.wrapping_mul(2))
+                    lap.wrapping_add(one_lap.wrapping_mul(2))
                 };
 
                 // Try moving the tail one entry forward.
@@ -166,18 +196,19 @@ impl<T> Channel<T> {
                     .compare_exchange_weak(tail, new_tail, SeqCst, Relaxed)
                     .is_ok()
                 {
-                    // Write the value into the entry and increment the lap.
-                    unsafe { ptr::write(entry.value.get(), value) }
+                    // Write the message into the entry and increment the lap.
+                    unsafe { ptr::write(entry.msg.get(), msg) }
                     entry.lap.store(next_elap, Release);
-                    return None;
+                    return Ok(());
                 }
             // But if the entry lags one lap behind the tail...
             } else if next_elap == lap {
                 let head = self.head.load(SeqCst);
+
                 // ...and if head lags one lap behind tail as well...
-                if head.wrapping_add(self.power) == tail {
-                    // ...then the queue is full.
-                    return Some(value);
+                if head.wrapping_add(one_lap) == tail {
+                    // ...then the channel is full.
+                    return Err(PushError::Full(msg));
                 }
             }
 
@@ -185,20 +216,24 @@ impl<T> Channel<T> {
         }
     }
 
-    /// Attempts to pop a value from the queue.
+    /// Attempts to pop a message from the channel.
     ///
-    /// Returns `None` if the queue is empty.
-    fn pop(&self, backoff: &mut Backoff) -> Option<T> {
+    /// Returns `None` if the channel is empty.
+    fn pop(&self, backoff: &mut Backoff) -> Result<T, PopError> {
+        let one_lap = self.mark_bit << 1;
+        let index_bits = self.mark_bit - 1;
+        let lap_bits = !(one_lap - 1);
+
         loop {
             // Load the head.
             let head = self.head.load(SeqCst);
-            let index = head & (self.power - 1);
-            let lap = head & !(self.power - 1);
+            let index = head & index_bits;
+            let lap = head & lap_bits;
 
             // Inspect the corresponding entry.
             let entry = unsafe { self.entry_at(index) };
             let elap = entry.lap.load(SeqCst);
-            let next_elap = elap.wrapping_add(self.power);
+            let next_elap = elap.wrapping_add(one_lap);
 
             // If the laps of the head and the entry match, we may attempt to pop.
             if lap == elap {
@@ -207,7 +242,7 @@ impl<T> Channel<T> {
                     head + 1
                 } else {
                     // Two laps forward; index wraps around to zero.
-                    lap.wrapping_add(self.power.wrapping_mul(2))
+                    lap.wrapping_add(one_lap.wrapping_mul(2))
                 };
 
                 // Try moving the head one entry forward.
@@ -215,18 +250,25 @@ impl<T> Channel<T> {
                     .compare_exchange_weak(head, new, SeqCst, Relaxed)
                     .is_ok()
                 {
-                    // Read the value from the entry and increment the lap.
-                    let value = unsafe { ptr::read(entry.value.get()) };
+                    // Read the message from the entry and increment the lap.
+                    let msg = unsafe { ptr::read(entry.msg.get()) };
                     entry.lap.store(next_elap, Release);
-                    return Some(value);
+                    return Ok(msg);
                 }
             // But if the entry lags one lap behind the head...
             } else if next_elap == lap {
                 let tail = self.tail.load(SeqCst);
-                // ...and if tail lags one lap behind head as well...
-                if tail.wrapping_add(self.power) == head {
-                    // ...then the queue is empty.
-                    return None;
+
+                // ...and if the tail lags one lap behind the head as well, that means the channel
+                // is empty.
+                if (tail & !self.mark_bit).wrapping_add(one_lap) == head {
+                    // Check whether the channel is disconnected and return the appropriate error
+                    // variant.
+                    if tail & self.mark_bit != 0 {
+                        return Err(PopError::Disconnected);
+                    } else {
+                        return Err(PopError::Empty);
+                    }
                 }
             }
 
@@ -236,6 +278,9 @@ impl<T> Channel<T> {
 
     /// Returns the current number of messages inside the channel.
     pub fn len(&self) -> usize {
+        let one_lap = self.mark_bit << 1;
+        let index_bits = self.mark_bit - 1;
+
         loop {
             // Load the tail, then load the head.
             let tail = self.tail.load(SeqCst);
@@ -243,14 +288,17 @@ impl<T> Channel<T> {
 
             // If the tail didn't change, we've got consistent values to work with.
             if self.tail.load(SeqCst) == tail {
-                let hix = head & (self.power - 1);
-                let tix = tail & (self.power - 1);
+                // Clear out the mark bit, just in case it is set.
+                let tail = tail & !self.mark_bit;
+
+                let hix = head & index_bits;
+                let tix = tail & index_bits;
 
                 return if hix < tix {
                     tix - hix
                 } else if hix > tix {
                     self.cap - hix + tix
-                } else if tail.wrapping_add(self.power) == head {
+                } else if tail.wrapping_add(one_lap) == head {
                     0
                 } else {
                     self.cap
@@ -261,16 +309,13 @@ impl<T> Channel<T> {
 
     /// Attempts to send `msg` into the channel.
     pub fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
-        if self.is_disconnected.load(SeqCst) {
-            Err(TrySendError::Disconnected(msg))
-        } else {
-            match self.push(msg, &mut Backoff::new()) {
-                None => {
-                    self.receivers.notify_one();
-                    Ok(())
-                }
-                Some(v) => Err(TrySendError::Full(v)),
+        match self.push(msg, &mut Backoff::new()) {
+            Ok(()) => {
+                self.receivers.notify_one();
+                Ok(())
             }
+            Err(PushError::Full(m)) => Err(TrySendError::Full(m)),
+            Err(PushError::Disconnected(m)) => Err(TrySendError::Disconnected(m)),
         }
     }
 
@@ -282,34 +327,31 @@ impl<T> Channel<T> {
         case_id: CaseId,
     ) -> Result<(), SendTimeoutError<T>> {
         loop {
-            if self.is_disconnected.load(SeqCst) {
-                return Err(SendTimeoutError::Disconnected(msg));
-            } else {
-                let backoff = &mut Backoff::new();
-                loop {
-                    match self.push(msg, backoff) {
-                        None => {
-                            self.receivers.notify_one();
-                            return Ok(());
-                        }
-                        Some(m) => msg = m,
+            let backoff = &mut Backoff::new();
+            loop {
+                match self.push(msg, backoff) {
+                    Ok(()) => {
+                        self.receivers.notify_one();
+                        return Ok(());
                     }
-                    if !backoff.step() {
-                        break;
+                    Err(PushError::Full(m)) => msg = m,
+                    Err(PushError::Disconnected(m)) => {
+                        return Err(SendTimeoutError::Disconnected(m));
                     }
+                }
+
+                if !backoff.step() {
+                    break;
                 }
             }
 
             handle::current_reset();
             self.senders.register(case_id);
-            let is_disconnected = self.is_disconnected();
             let timed_out =
-                !is_disconnected && self.is_full() && !handle::current_wait_until(deadline);
+                !self.is_disconnected() && self.is_full() && !handle::current_wait_until(deadline);
             self.senders.unregister(case_id);
 
-            if is_disconnected {
-                return Err(SendTimeoutError::Disconnected(msg));
-            } else if timed_out {
+            if timed_out {
                 return Err(SendTimeoutError::Timeout(msg));
             }
         }
@@ -317,19 +359,13 @@ impl<T> Channel<T> {
 
     /// Attempts to receive a message from channel.
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
-        let is_disconnected = self.is_disconnected.load(SeqCst);
         match self.pop(&mut Backoff::new()) {
-            Some(msg) => {
+            Ok(m) => {
                 self.senders.notify_one();
-                Ok(msg)
+                Ok(m)
             }
-            None => {
-                if is_disconnected {
-                    Err(TryRecvError::Disconnected)
-                } else {
-                    Err(TryRecvError::Empty)
-                }
-            }
+            Err(PopError::Empty) => Err(TryRecvError::Empty),
+            Err(PopError::Disconnected) => Err(TryRecvError::Disconnected),
         }
     }
 
@@ -342,14 +378,15 @@ impl<T> Channel<T> {
         loop {
             let backoff = &mut Backoff::new();
             loop {
-                let is_disconnected = self.is_disconnected.load(SeqCst);
-                if let Some(v) = self.pop(backoff) {
-                    self.senders.notify_one();
-                    return Ok(v);
+                match self.pop(backoff) {
+                    Ok(m) => {
+                        self.senders.notify_one();
+                        return Ok(m);
+                    }
+                    Err(PopError::Empty) => {},
+                    Err(PopError::Disconnected) => return Err(RecvTimeoutError::Disconnected),
                 }
-                if is_disconnected {
-                    return Err(RecvTimeoutError::Disconnected);
-                }
+
                 if !backoff.step() {
                     break;
                 }
@@ -357,14 +394,11 @@ impl<T> Channel<T> {
 
             handle::current_reset();
             self.receivers.register(case_id);
-            let is_disconnected = self.is_disconnected();
             let timed_out =
-                !is_disconnected && self.is_empty() && !handle::current_wait_until(deadline);
+                !self.is_disconnected() && self.is_empty() && !handle::current_wait_until(deadline);
             self.receivers.unregister(case_id);
 
-            if is_disconnected && self.is_empty() {
-                return Err(RecvTimeoutError::Disconnected);
-            } else if timed_out {
+            if timed_out {
                 return Err(RecvTimeoutError::Timeout);
             }
         }
@@ -377,7 +411,10 @@ impl<T> Channel<T> {
 
     /// Disconnects the channel and wakes up all currently blocked operations on it.
     pub fn disconnect(&self) -> bool {
-        if self.is_disconnected.swap(true, SeqCst) {
+        let tail = self.tail.fetch_or(self.mark_bit, SeqCst);
+
+        // Was the channel already disconnected?
+        if tail & self.mark_bit != 0 {
             false
         } else {
             self.senders.abort_all();
@@ -388,21 +425,27 @@ impl<T> Channel<T> {
 
     /// Returns `true` if the channel is disconnected.
     pub fn is_disconnected(&self) -> bool {
-        self.is_disconnected.load(SeqCst)
+        self.tail.load(SeqCst) & self.mark_bit != 0
     }
 
     /// Returns `true` if the channel is empty.
     pub fn is_empty(&self) -> bool {
         let head = self.head.load(SeqCst);
-        let tail = self.tail.load(SeqCst);
-        tail.wrapping_add(self.power) == head
+        let tail = self.tail.load(SeqCst) & !self.mark_bit;
+
+        // Is the tail lagging one lap behind head?
+        let one_lap = self.mark_bit << 1;
+        tail.wrapping_add(one_lap) == head
     }
 
     /// Returns `true` if the channel is full.
     pub fn is_full(&self) -> bool {
-        let tail = self.tail.load(SeqCst);
+        let tail = self.tail.load(SeqCst) & !self.mark_bit;
         let head = self.head.load(SeqCst);
-        head.wrapping_add(self.power) == tail
+
+        // Is the head lagging one lap behind tail?
+        let one_lap = self.mark_bit << 1;
+        head.wrapping_add(one_lap) == tail
     }
 
     /// Returns a reference to the monitor for this channel's senders.
@@ -418,9 +461,10 @@ impl<T> Channel<T> {
 
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
-        let head = self.head.load(Relaxed) & (self.power - 1);
+        let index_bits = self.mark_bit - 1;
+        let head = self.head.load(Relaxed) & index_bits;
 
-        // Loop over all entries that hold a value and drop them.
+        // Loop over all entries that hold a message and drop them.
         for i in 0..self.len() {
             let index = if head + i < self.cap {
                 head + i

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -19,28 +19,39 @@ use select::CaseId;
 use select::handle;
 use utils::Backoff;
 
-/// Number of values a node can hold.
+/// Number of messages a node can hold.
 const NODE_CAP: usize = 32;
 
 /// An entry in a node of the linked list.
 struct Entry<T> {
-    /// The value in this entry.
-    value: ManuallyDrop<T>,
+    /// The message in this entry.
+    msg: ManuallyDrop<T>,
 
-    /// Whether the value is ready for reading.
+    /// Whether the message is ready for reading.
     ready: AtomicBool,
+}
+
+/// Indicates that the `push` operation failed due to the channel being disconnected.
+struct PushError<T>(T);
+
+/// The list of possible error outcomes for the `pop` operation.
+enum PopError {
+    /// The channel is empty.
+    Empty,
+
+    /// The channel is disconnected.
+    Disconnected,
 }
 
 /// A node in the linked list.
 ///
-/// Each node in the list can hold up to `NODE_CAP` values. Storing multiple values in a node
-/// improves cache locality and reduces the total amount of allocation.
+/// Each node in the list can hold up to `NODE_CAP` messages. Storing multiple messages in a node
+/// improves cache locality and reduces the total number of allocations.
 struct Node<T> {
-    /// Start index of this node.
-    /// Indices span the range `start_index .. start_index + NODE_CAP`.
+    /// The start index of this node.
     start_index: usize,
 
-    /// Entries containing values.
+    /// The entries containing messages.
     entries: [UnsafeCell<Entry<T>>; NODE_CAP],
 
     /// The next node in the linked list.
@@ -58,13 +69,11 @@ impl<T> Node<T> {
     }
 }
 
-/// A position in the queue (index and node).
+/// A position in the channel (index and node).
 ///
 /// This struct marks the current position of the head or the tail in a linked list.
 struct Position<T> {
-    /// The index in the queue.
-    ///
-    /// Indices wrap around on overflow.
+    /// The index in the channel.
     index: AtomicUsize,
 
     /// The node in the linked list.
@@ -73,18 +82,21 @@ struct Position<T> {
 
 /// A channel of unbounded capacity based on a linked list.
 ///
-/// The internal queue can be thought of as an array of infinite length. Head and tail indices
-/// point into the array and wrap around on overflow. This infinite array is implemented as a
-/// linked list of nodes, each of which has enough space to contain a few dozen values.
+/// The internal queue can be thought of as an array of infinite length, implemented as a linked
+/// list of nodes, each of which has enough space to contain a few dozen messages. Fitting multiple
+/// messages into a single node improves cache locality and reduces the number of allocations.
+///
+/// An index is a number of type `usize` that represents an entry in the message queue. Each node
+/// contains a `start_index` representing the index of its first message. Indices simply wrap
+/// around on overflow. Also note that the last bit of an index is reserved for marking, while the
+/// rest of the bits represent the actual position in the sequence of messages. When the tail index
+/// is marked, that means the channel is disconnected and the tail cannot move forward any further.
 pub struct Channel<T> {
     /// The current head index and the node containing it.
     head: CachePadded<Position<T>>,
 
     /// The current tail index and the node containing it.
     tail: CachePadded<Position<T>>,
-
-    /// Equals `true` if the channel is disconnected.
-    is_disconnected: AtomicBool,
 
     /// Receivers waiting on empty channel.
     receivers: Monitor,
@@ -104,7 +116,6 @@ impl<T> Channel<T> {
                 index: AtomicUsize::new(0),
                 node: Atomic::null(),
             }),
-            is_disconnected: AtomicBool::new(false),
             receivers: Monitor::new(),
             _marker: PhantomData,
         };
@@ -117,21 +128,32 @@ impl<T> Channel<T> {
         channel
     }
 
-    /// Pushes `value` into the queue.
-    fn push(&self, value: T) {
+    /// Pushes `msg` into the channel.
+    fn push(&self, msg: T, backoff: &mut Backoff) -> Result<(), PushError<T>> {
         let guard = &epoch::pin();
 
-        let mut backoff = Backoff::new();
         loop {
-            let tail = unsafe { self.tail.node.load(Acquire, guard).deref() };
-            let index = self.tail.index.load(Relaxed);
-            let new_index = index.wrapping_add(1);
-            let offset = index.wrapping_sub(tail.start_index);
+            // These two load operations don't have to be `SeqCst`. If they happen to retrieve
+            // stale values, the following CAS will fail or not even be attempted.
+            let tail_ptr = self.tail.node.load(Acquire, guard);
+            let tail = unsafe { tail_ptr.deref() };
+            let tail_index = self.tail.index.load(Relaxed);
 
-            // If `index` is pointing into `tail`...
+            // If the tail index is marked, the channel is disconnected.
+            if tail_index & 1 != 0 {
+                return Err(PushError(msg));
+            }
+
+            // Calculate the index of the corresponding entry in the node.
+            let offset = tail_index.wrapping_sub(tail.start_index) >> 1;
+
+            // Advance the current index one entry forward.
+            let new_index = tail_index.wrapping_add(1 << 1);
+
+            // If `tail_index` is pointing into `tail`...
             if offset < NODE_CAP {
-                // if `index` is pointing into `tail`, try moving the tail index forward.
-                if self.tail.index.compare_and_swap(index, new_index, SeqCst) == index {
+                // Try moving the tail index forward.
+                if self.tail.index.compare_and_swap(tail_index, new_index, SeqCst) == tail_index {
                     // If this was the last entry in the node, allocate a new one.
                     if offset + 1 == NODE_CAP {
                         let new = Owned::new(Node::new(new_index)).into_shared(guard);
@@ -139,13 +161,13 @@ impl<T> Channel<T> {
                         self.tail.node.store(new, Release);
                     }
 
-                    // Write `value` into the corresponding entry.
+                    // Write `msg` into the corresponding entry.
                     unsafe {
                         let entry = tail.entries.get_unchecked(offset).get();
-                        ptr::write(&mut (*entry).value, ManuallyDrop::new(value));
+                        ptr::write(&mut (*entry).msg, ManuallyDrop::new(msg));
                         (*entry).ready.store(true, Release);
                     }
-                    return;
+                    return Ok(());
                 }
             }
 
@@ -153,32 +175,49 @@ impl<T> Channel<T> {
         }
     }
 
-    /// Attempts to pop a value from the queue.
+    /// Attempts to pop a message from the channel.
     ///
-    /// Returns `None` if the queue is empty.
-    fn pop(&self) -> Option<T> {
+    /// Returns `None` if the channel is empty.
+    fn pop(&self, backoff: &mut Backoff) -> Result<T, PopError> {
         let guard = &epoch::pin();
 
-        let mut backoff = Backoff::new();
         loop {
+            // Loading the head node doesn't't have to be a `SeqCst` operation. If we get a stale
+            // value, the following CAS will fail or not even be attempted. Loading the head index
+            // must be `SeqCst` because we need the up-to-date value when checking whether the
+            // channel is empty.
             let head_ptr = self.head.node.load(Acquire, guard);
             let head = unsafe { head_ptr.deref() };
-            let index = self.head.index.load(SeqCst);
-            let new_index = index.wrapping_add(1);
-            let offset = index.wrapping_sub(head.start_index);
+            let head_index = self.head.index.load(SeqCst);
 
-            // If `index` is pointing into `head`...
+            // Calculate the index of the corresponding entry in the node.
+            let offset = head_index.wrapping_sub(head.start_index) >> 1;
+
+            // Advance the current index one entry forward.
+            let new_index = head_index.wrapping_add(1 << 1);
+
+            // If `head_index` is pointing into `head`...
             if offset < NODE_CAP {
                 let entry = unsafe { &*head.entries.get_unchecked(offset).get() };
 
-                // If this entry does not contain the value and the tail equals the head, then the
-                // queue is empty.
-                if !entry.ready.load(Relaxed) && self.tail.index.load(SeqCst) == index {
-                    return None;
+                // If this entry does not contain a message...
+                if !entry.ready.load(Relaxed) {
+                    let tail_index = self.tail.index.load(SeqCst);
+
+                    // If the tail equals the head, that means the channel is empty.
+                    if tail_index & !1 == head_index {
+                        // Check whether the channel is disconnected and return the appropriate
+                        // error variant.
+                        if tail_index & 1 == 0 {
+                            return Err(PopError::Empty);
+                        } else {
+                            return Err(PopError::Disconnected);
+                        }
+                    }
                 }
 
                 // Try moving the head index forward.
-                if self.head.index.compare_and_swap(index, new_index, SeqCst) == index {
+                if self.head.index.compare_and_swap(head_index, new_index, SeqCst) == head_index {
                     // If this was the last entry in the node, defer its destruction.
                     if offset + 1 == NODE_CAP {
                         // Wait until the next pointer becomes non-null.
@@ -200,9 +239,9 @@ impl<T> Channel<T> {
                         backoff.step();
                     }
 
-                    let v = unsafe { ptr::read(&(*entry).value) };
-                    let value = ManuallyDrop::into_inner(v);
-                    return Some(value);
+                    let m = unsafe { ptr::read(&(*entry).msg) };
+                    let msg = ManuallyDrop::into_inner(m);
+                    return Ok(msg);
                 }
             }
 
@@ -218,45 +257,41 @@ impl<T> Channel<T> {
 
             // If the tail index didn't change, we've got consistent indices to work with.
             if self.tail.index.load(SeqCst) == tail_index {
-                return tail_index.wrapping_sub(head_index);
+                // Note that there is no need to clear out the last bit in `tail_index` since the
+                // difference is shifted right by one bit.
+                return tail_index.wrapping_sub(head_index) >> 1;
             }
         }
     }
 
     /// Attempts to send `msg` into the channel.
     pub fn try_send(&self, msg: T) -> Result<(), TrySendError<T>> {
-        if self.is_disconnected.load(SeqCst) {
-            Err(TrySendError::Disconnected(msg))
-        } else {
-            self.push(msg);
-            self.receivers.notify_one();
-            Ok(())
+        match self.push(msg, &mut Backoff::new()) {
+            Ok(()) => {
+                self.receivers.notify_one();
+                Ok(())
+            }
+            Err(PushError(m)) => Err(TrySendError::Disconnected(m)),
         }
     }
 
     /// Send `msg` into the channel.
     pub fn send(&self, msg: T) -> Result<(), SendTimeoutError<T>> {
-        if self.is_disconnected.load(SeqCst) {
-            Err(SendTimeoutError::Disconnected(msg))
-        } else {
-            self.push(msg);
-            self.receivers.notify_one();
-            Ok(())
+        match self.push(msg, &mut Backoff::new()) {
+            Ok(()) => {
+                self.receivers.notify_one();
+                Ok(())
+            }
+            Err(PushError(m)) => Err(SendTimeoutError::Disconnected(m)),
         }
     }
 
     /// Attempts to receive a message from channel.
     pub fn try_recv(&self) -> Result<T, TryRecvError> {
-        let is_disconnected = self.is_disconnected.load(SeqCst);
-        match self.pop() {
-            None => {
-                if is_disconnected {
-                    Err(TryRecvError::Disconnected)
-                } else {
-                    Err(TryRecvError::Empty)
-                }
-            }
-            Some(msg) => Ok(msg),
+        match self.pop(&mut Backoff::new()) {
+            Ok(m) => Ok(m),
+            Err(PopError::Empty) => Err(TryRecvError::Empty),
+            Err(PopError::Disconnected) => Err(TryRecvError::Disconnected),
         }
     }
 
@@ -269,13 +304,12 @@ impl<T> Channel<T> {
         loop {
             let backoff = &mut Backoff::new();
             loop {
-                let is_disconnected = self.is_disconnected.load(SeqCst);
-                if let Some(msg) = self.pop() {
-                    return Ok(msg);
+                match self.pop(backoff) {
+                    Ok(m) => return Ok(m),
+                    Err(PopError::Empty) => {},
+                    Err(PopError::Disconnected) => return Err(RecvTimeoutError::Disconnected),
                 }
-                if is_disconnected {
-                    return Err(RecvTimeoutError::Disconnected);
-                }
+
                 if !backoff.step() {
                     break;
                 }
@@ -283,14 +317,11 @@ impl<T> Channel<T> {
 
             handle::current_reset();
             self.receivers.register(case_id);
-            let is_disconnected = self.is_disconnected();
             let timed_out =
-                !is_disconnected && self.is_empty() && !handle::current_wait_until(deadline);
+                !self.is_disconnected() && self.is_empty() && !handle::current_wait_until(deadline);
             self.receivers.unregister(case_id);
 
-            if is_disconnected && self.is_empty() {
-                return Err(RecvTimeoutError::Disconnected);
-            } else if timed_out {
+            if timed_out {
                 return Err(RecvTimeoutError::Timeout);
             }
         }
@@ -298,7 +329,10 @@ impl<T> Channel<T> {
 
     /// Disconnects the channel and wakes up all currently blocked operations on it.
     pub fn disconnect(&self) -> bool {
-        if self.is_disconnected.swap(true, SeqCst) {
+        let tail_index = self.tail.index.fetch_or(1, SeqCst);
+
+        // Was the channel already disconnected?
+        if tail_index & 1 != 0 {
             false
         } else {
             self.receivers.abort_all();
@@ -308,13 +342,13 @@ impl<T> Channel<T> {
 
     /// Returns `true` if the channel is disconnected.
     pub fn is_disconnected(&self) -> bool {
-        self.is_disconnected.load(SeqCst)
+        self.tail.index.load(SeqCst) & 1 != 0
     }
 
     /// Returns `true` if the channel is empty.
     pub fn is_empty(&self) -> bool {
         let head_index = self.head.index.load(SeqCst);
-        let tail_index = self.tail.index.load(SeqCst);
+        let tail_index = self.tail.index.load(SeqCst) & !1;
         head_index == tail_index
     }
 
@@ -326,20 +360,20 @@ impl<T> Channel<T> {
 
 impl<T> Drop for Channel<T> {
     fn drop(&mut self) {
-        let tail_index = self.tail.index.load(Relaxed);
+        let tail_index = self.tail.index.load(Relaxed) & !1;
         let mut head_index = self.head.index.load(Relaxed);
 
         unsafe {
             let mut head_ptr = self.head.node.load(Relaxed, epoch::unprotected());
 
-            // Manually drop all values between `head_index` and `tail_index` and destroy the
+            // Manually drop all messages between `head_index` and `tail_index` and destroy the
             // heap-allocated nodes along the way.
             while head_index != tail_index {
                 let head = head_ptr.deref();
-                let offset = head_index.wrapping_sub(head.start_index);
+                let offset = head_index.wrapping_sub(head.start_index) >> 1;
 
                 let entry = &mut *head.entries.get_unchecked(offset).get();
-                ManuallyDrop::drop(&mut (*entry).value);
+                ManuallyDrop::drop(&mut (*entry).msg);
 
                 if offset + 1 == NODE_CAP {
                     let next = head.next.load(Relaxed, epoch::unprotected());
@@ -347,7 +381,7 @@ impl<T> Drop for Channel<T> {
                     head_ptr = next;
                 }
 
-                head_index = head_index.wrapping_add(1);
+                head_index = head_index.wrapping_add(1 << 1);
             }
 
             // If there is one last remaining node in the end, destroy it.

--- a/src/flavors/zero.rs
+++ b/src/flavors/zero.rs
@@ -115,13 +115,13 @@ impl<T> Channel<T> {
         self.exchanger.right().can_notify()
     }
 
-    /// Closes the channel and wakes up all currently blocked operations on it.
-    pub fn close(&self) -> bool {
-        self.exchanger.close()
+    /// Disconnects the channel and wakes up all currently blocked operations on it.
+    pub fn disconnect(&self) -> bool {
+        self.exchanger.disconnect()
     }
 
-    /// Returns `true` if the channel is closed.
-    pub fn is_closed(&self) -> bool {
-        self.exchanger.is_closed()
+    /// Returns `true` if the channel is disconnected.
+    pub fn is_disconnected(&self) -> bool {
+        self.exchanger.is_disconnected()
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -23,7 +23,7 @@ struct Case {
 /// A simple wait queue for list-based and array-based channels.
 ///
 /// This data structure is used sfor registeroing selection cases before blocking and waking them
-/// up when the channel receives a message, sends one, or becomes closed.
+/// up when the channel receives a message, sends one, or becomes disconnected.
 pub struct Monitor {
     /// The list of registered selection cases.
     cases: Mutex<VecDeque<Case>>,

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -173,7 +173,7 @@ fn try_send() {
 }
 
 #[test]
-fn send_close() {
+fn send_disconnected() {
     let (tx, rx) = bounded(0);
 
     crossbeam::scope(|s| {
@@ -184,14 +184,14 @@ fn send_close() {
         s.spawn(move || {
             assert_eq!(rx.recv(), Ok(1));
             thread::sleep(ms(1000));
-            rx.close();
+            rx.disconnect();
             assert_eq!(rx.recv(), Err(RecvError));
         });
     });
 }
 
 #[test]
-fn recv_after_close() {
+fn recv_after_disconnect() {
     let (tx, rx) = bounded(100);
 
     tx.send(1).unwrap();
@@ -303,7 +303,7 @@ fn len() {
 }
 
 #[test]
-fn drop_signals_sender() {
+fn dropping_receiver_signals_sender() {
     let (tx, rx) = bounded(1);
 
     crossbeam::scope(|s| {
@@ -319,7 +319,7 @@ fn drop_signals_sender() {
 }
 
 #[test]
-fn close_signals_sender() {
+fn disconnect_signals_sender() {
     let (tx, rx) = bounded(1);
 
     crossbeam::scope(|s| {
@@ -329,7 +329,7 @@ fn close_signals_sender() {
         });
         s.spawn(move || {
             thread::sleep(ms(1000));
-            rx.close();
+            rx.disconnect();
             assert_eq!(rx.recv(), Ok(1));
             assert_eq!(rx.recv(), Err(RecvError));
         });
@@ -337,7 +337,7 @@ fn close_signals_sender() {
 }
 
 #[test]
-fn close_signals_receiver() {
+fn disconnect_signals_receiver() {
     let (tx, rx) = bounded::<()>(1);
 
     crossbeam::scope(|s| {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 use crossbeam_channel::unbounded;
-use crossbeam_channel::{RecvError, RecvTimeoutError, TryRecvError};
+use crossbeam_channel::{RecvError, RecvTimeoutError, SendError, TryRecvError};
 use rand::{thread_rng, Rng};
 
 fn ms(ms: u64) -> Duration {
@@ -164,6 +164,27 @@ fn len() {
 
     assert_eq!(tx.len(), 0);
     assert_eq!(rx.len(), 0);
+}
+
+#[test]
+fn close_signals_sender() {
+    let (tx, rx) = unbounded();
+
+    crossbeam::scope(|s| {
+        s.spawn(move || {
+            assert_eq!(tx.send(1), Ok(()));
+            assert_eq!(tx.send(2), Ok(()));
+            thread::sleep(ms(1000));
+            assert_eq!(tx.send(3), Err(SendError(3)));
+        });
+        s.spawn(move || {
+            thread::sleep(ms(500));
+            rx.close();
+            assert_eq!(rx.recv(), Ok(1));
+            assert_eq!(rx.recv(), Ok(2));
+            assert_eq!(rx.recv(), Err(RecvError));
+        });
+    });
 }
 
 #[test]

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -93,7 +93,7 @@ fn try_recv() {
 }
 
 #[test]
-fn recv_after_close() {
+fn recv_after_disconnect() {
     let (tx, rx) = unbounded();
 
     tx.send(1).unwrap();
@@ -167,7 +167,7 @@ fn len() {
 }
 
 #[test]
-fn close_signals_sender() {
+fn disconnect_signals_sender() {
     let (tx, rx) = unbounded();
 
     crossbeam::scope(|s| {
@@ -179,7 +179,7 @@ fn close_signals_sender() {
         });
         s.spawn(move || {
             thread::sleep(ms(500));
-            rx.close();
+            rx.disconnect();
             assert_eq!(rx.recv(), Ok(1));
             assert_eq!(rx.recv(), Ok(2));
             assert_eq!(rx.recv(), Err(RecvError));
@@ -188,7 +188,7 @@ fn close_signals_sender() {
 }
 
 #[test]
-fn close_signals_receiver() {
+fn disconnect_signals_receiver() {
     let (tx, rx) = unbounded::<()>();
 
     crossbeam::scope(|s| {

--- a/tests/select.rs
+++ b/tests/select.rs
@@ -1154,7 +1154,7 @@ fn try_send() {
 }
 
 #[test]
-fn recv_after_close() {
+fn recv_after_disconnect() {
     let (tx, rx) = bounded(100);
     let tx = WrappedSender(tx);
     let rx = WrappedReceiver(rx);

--- a/tests/select_loop.rs
+++ b/tests/select_loop.rs
@@ -818,7 +818,7 @@ fn try_send() {
 }
 
 #[test]
-fn recv_after_close() {
+fn recv_after_disconnect() {
     let (tx, rx) = bounded(100);
     let tx = WrappedSender(tx);
     let rx = WrappedReceiver(rx);

--- a/tests/zero.rs
+++ b/tests/zero.rs
@@ -218,7 +218,7 @@ fn len() {
 }
 
 #[test]
-fn close_signals_sender() {
+fn drop_signals_sender() {
     let (tx, rx) = bounded(0);
 
     crossbeam::scope(|s| {
@@ -228,6 +228,21 @@ fn close_signals_sender() {
         s.spawn(move || {
             thread::sleep(ms(1000));
             drop(rx);
+        });
+    });
+}
+
+#[test]
+fn close_signals_sender() {
+    let (tx, rx) = bounded(0);
+
+    crossbeam::scope(|s| {
+        s.spawn(move || {
+            assert_eq!(tx.send(()), Err(SendError(())));
+        });
+        s.spawn(move || {
+            thread::sleep(ms(1000));
+            rx.close();
         });
     });
 }

--- a/tests/zero.rs
+++ b/tests/zero.rs
@@ -218,7 +218,7 @@ fn len() {
 }
 
 #[test]
-fn drop_signals_sender() {
+fn dropping_receiver_signals_sender() {
     let (tx, rx) = bounded(0);
 
     crossbeam::scope(|s| {
@@ -233,7 +233,7 @@ fn drop_signals_sender() {
 }
 
 #[test]
-fn close_signals_sender() {
+fn disconnect_signals_sender() {
     let (tx, rx) = bounded(0);
 
     crossbeam::scope(|s| {
@@ -242,13 +242,13 @@ fn close_signals_sender() {
         });
         s.spawn(move || {
             thread::sleep(ms(1000));
-            rx.close();
+            rx.disconnect();
         });
     });
 }
 
 #[test]
-fn close_signals_receiver() {
+fn disconnect_signals_receiver() {
     let (tx, rx) = bounded::<()>(0);
 
     crossbeam::scope(|s| {


### PR DESCRIPTION
I haven't done a full code review to make sure this is legal for each of
the channel flavors, but the tests indicate it works appropriately.
There is prior-art for this feature in [`futures-rs`'s channel implementation][1].

[1]: https://docs.rs/futures/0.1.17/futures/sync/mpsc/struct.Receiver.html#method.close