### PR TITLE
Update crossbeam-utils to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossbeam-channel"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Crossbeam Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -17,6 +17,6 @@ nightly = []
 [dependencies]
 crossbeam = "0.3.0"
 crossbeam-epoch = "0.2.0"
-crossbeam-utils = "0.1.0"
+crossbeam-utils = "0.2.0"
 parking_lot = "0.4.4"
 rand = "0.3"


### PR DESCRIPTION
… which is already used by crossbeam-epoch, so this avoids compiling two copies.