### PR TITLE
Support broadcasting

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,0 +1,56 @@
+use parking_lot::RwLock;
+
+use channel::Sender;
+
+pub struct Broadcast<T> {
+    senders: RwLock<Vec<Sender<T>>>,
+}
+
+unsafe impl<T: Send> Send for Broadcast<T> {}
+unsafe impl<T: Send> Sync for Broadcast<T> {}
+
+impl<T> Broadcast<T> {
+    pub fn new() -> Broadcast<T> {
+        Broadcast {
+            senders: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub fn register(&self, tx: Sender<T>) {
+        self.senders.write().push(tx);
+    }
+}
+
+impl<T: Clone> Broadcast<T> {
+    pub fn broadcast(&self, msg: T) {
+        let mut needs_cleanup = false;
+
+        {
+            let senders = self.senders.write();
+
+            for s in senders.iter().skip(1) {
+                if s.send(msg.clone()).is_err() {
+                    needs_cleanup = true;
+                }
+            }
+
+            if let Some(s) = senders.get(0) {
+                if s.send(msg).is_err() {
+                    needs_cleanup = true;
+                }
+            }
+        }
+
+        if needs_cleanup {
+            self.senders.write().retain(|s| !s.is_disconnected());
+        }
+    }
+}
+
+impl<T> Clone for Broadcast<T> {
+    fn clone(&self) -> Broadcast<T> {
+        Broadcast {
+            senders: RwLock::new(self.senders.read().clone()),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,7 @@ extern crate crossbeam_epoch;
 extern crate crossbeam_utils;
 extern crate parking_lot;
 
+mod broadcast;
 mod channel;
 mod err;
 mod exchanger;
@@ -333,6 +334,7 @@ mod monitor;
 mod select;
 mod utils;
 
+pub use broadcast::Broadcast;
 pub use channel::{bounded, unbounded};
 pub use channel::{Receiver, Sender};
 pub use channel::{IntoIter, Iter, TryIter};

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -1,0 +1,19 @@
+extern crate crossbeam;
+extern crate crossbeam_channel;
+
+use crossbeam_channel::{Broadcast, bounded, unbounded};
+
+#[test]
+fn smoke() {
+    let (tx1, rx1) = bounded(1);
+    let (tx2, rx2) = unbounded();
+
+    let b = Broadcast::new();
+    b.register(tx1);
+    b.register(tx2);
+    b.broadcast(1);
+    drop(b);
+
+    assert_eq!(rx1.into_iter().collect::<Vec<_>>(), [1]);
+    assert_eq!(rx2.into_iter().collect::<Vec<_>>(), [1]);
+}


### PR DESCRIPTION
WIP: This PR still needs more tests and documentation.

Also, broadcasting from multiple threads at the same time creates a lot of contention around the `RwLock`, which has a noticeable negative effect on performance. We should try working around the contention by designing a custom, more scalable reader-writer lock.

Closes #24 
cc @dbrgn