### PR TITLE
WIP: Unbounded futures mpmc channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 Cargo.lock
+.idea
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ nightly = []
 crossbeam-epoch = "0.2.0"
 crossbeam-utils = "0.2.0"
 parking_lot = "0.5"
+futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
 crossbeam = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ nightly = []
 crossbeam-epoch = "0.2.0"
 crossbeam-utils = "0.2.0"
 parking_lot = "0.5"
-futures = { version = "0.1", optional = true }
+futures = { version = "0.1" }
 
 [dev-dependencies]
 crossbeam = "0.3.0"

--- a/src/flavors/array.rs
+++ b/src/flavors/array.rs
@@ -158,7 +158,7 @@ impl<T> Channel<T> {
 
     /// Attempts to push `msg` into the channel.
     ///
-    /// Returns `None` on success, and `Some(msg)` if the channel is full.
+    /// Returns `Ok` on success, and `PushError(msg)` if the channel is full or disconnected.
     fn push(&self, msg: T, backoff: &mut Backoff) -> Result<(), PushError<T>> {
         let one_lap = self.mark_bit << 1;
         let index_bits = self.mark_bit - 1;

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -1,0 +1,2 @@
+mod sender_task;
+pub mod mpsc;

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -1,2 +1,3 @@
 mod sender_task;
 pub mod mpsc;
+pub mod mpmc;

--- a/src/futures/mpmc.rs
+++ b/src/futures/mpmc.rs
@@ -1,0 +1,370 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+
+use futures_rs::{
+	Async,
+	AsyncSink,
+	Poll,
+	Sink,
+	Stream,
+	StartSend,
+};
+
+use flavors::list;
+use err::{
+	SendError,
+	TryRecvError,
+	TrySendError,
+};
+use futures::sender_task::SenderTask;
+
+
+/// The inner channel data structure shared among the senders and the receiver of a future-aware
+/// mpsc channel.
+struct Channel<T> {
+	/// The count of `Sender` handles outstanding. When the count reaches 0, the final `Sender`
+	/// will disconnect the `items` and `sender_tasks` channels and notify the receiver task that
+	/// the channel is no longer active.
+	senders: AtomicUsize,
+
+	receivers: AtomicUsize,
+
+	/// The bounded queue of items. `Sender`s push to the channel, and the `Receiver` pops items
+	/// as they become available.
+	items: list::Channel<T>,
+
+	/// An unbounded queue of parked `Sender` tasks which are waiting for capacity in the `items`
+	/// channel to become available.
+	///
+	/// ## `Sender` Usage
+	///
+	/// During the first attempt to send an item to a channel, if the `Sender` discovers that there
+	/// is no channel capacity available, it will create a new `SenderTask`, send it to this
+	/// channel, and park itself (return `NotReady`).
+	///
+	/// During subsequent attempts to send the item to the channel, the `Sender` will
+	/// simultaneously register it's task with the `SenderTask` and check if the `SenderTask` has
+	/// already been notified (and thus removed from the `senders_task` queue) via
+	/// `SenderTask::register`. If during this subsequent attempt to send an item there is still no
+	/// capacity, and the existing `SenderTask` has already been notified, then the `Sender` will
+	/// enqueue a a new `SenderTask` to this channel to ensure it will be notified.
+	///
+	/// ## `Receiver` Usage
+	///
+	/// When there is channel capacity available, the `Receiver` is responsible for dequeing sender
+	/// tasks from this channel and notifying them. The `Receiver` will notify one sender task per
+	/// item dequeued from the `items` channel.
+	///
+	/// ## Notes on `Sender::drop`
+	///
+	/// If a `Sender` is dropped while it has a sender task enqueued on this channel, it is
+	/// responsible for notifying an alternate sender task. This ensures that there are no 'lost
+	/// wakeups', which can occur when the `Receiver` notifies a sender task, but the sender task
+	/// is immediately dropped, or never again attempts to send an item to the channel.
+	sender_tasks: list::Channel<Arc<SenderTask>>,
+
+	/// A notifier for the `Receiver`'s task.
+	///
+	/// `Sender` instances are responsible for notifying the `Receiver` after taking any action
+	/// which the `Receiver` must wake up to handle.
+	///
+	/// * a new item is enqueued to `items`
+	/// * a new parked sender task is enqueued to `sender_tasks`
+	/// * the final `Sender` is dropped, and the channel is disconnected
+	receiver_tasks: list::Channel<Arc<SenderTask>>,
+}
+
+impl<T> Channel<T> {
+	/// Notifies a single sender task that channel capacity is available.
+	fn notify_one_sender(&self) {
+		while let Ok(sender) = self.sender_tasks.try_recv() {
+			if sender.notify().is_ok() {
+				break;
+			}
+		}
+	}
+
+	/// Notifies all sender tasks that the channel has been disconnected.
+	fn notify_all_senders(&self) {
+		debug_assert!(self.items.is_disconnected());
+		debug_assert!(self.sender_tasks.is_disconnected());
+		while let Ok(sender) = self.sender_tasks.try_recv() {
+			let _ = sender.notify();
+		}
+	}
+
+	fn notify_one_receiver(&self) {
+		while let Ok(receiver) = self.receiver_tasks.try_recv() {
+			if receiver.notify().is_ok() {
+				break;
+			}
+		}
+	}
+
+	/// Notifies all receiver tasks that the channel has been disconnected.
+	fn notify_all_receivers(&self) {
+		debug_assert!(self.items.is_disconnected());
+		debug_assert!(self.receiver_tasks.is_disconnected());
+		while let Ok(receiver) = self.receiver_tasks.try_recv() {
+			let _ = receiver.notify();
+		}
+	}
+}
+
+/// Creates an in-memory, unbounded, futures-aware MPSC channel.
+///
+/// This method returns `Sender` and `Receiver` instance which can be used to send values across
+/// tasks. This channel is unique in that it implements back pressure to ensure that the sender
+/// never outpaces the receiver. The channel will refuse sending new items when there are `cap`
+/// items already in-flight.
+///
+/// The `Receiver` returned implements the `Stream` trait and has access to all of the associated
+/// combinators for transforming the result.
+///
+/// The `Sender` returned implements the `Sink` trait and has access to all of the associated
+/// combinators to transform the input. `Sender` may be cloned freely and sent across tasks.
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+	let channel = Arc::new(Channel {
+		senders: AtomicUsize::new(1),
+		receivers: AtomicUsize::new(1),
+		items: list::Channel::new(),
+		sender_tasks: list::Channel::new(),
+		receiver_tasks: list::Channel::new(),
+	});
+	let sender = Sender {
+		channel: channel.clone(),
+		task: None,
+	};
+	let receiver = Receiver {
+		channel,
+		task: None,
+	};
+	(sender, receiver)
+}
+
+/// The producer, or sender half of a futures-aware, bounded, MPSC channel.
+pub struct Sender<T> {
+	channel: Arc<Channel<T>>,
+	task: Option<Arc<SenderTask>>,
+}
+
+unsafe impl<T: Send> Send for Sender<T> {}
+
+unsafe impl<T: Send> Sync for Sender<T> {}
+
+impl<T> Sender<T> {
+	/// Attempts to send a message on this `Sender` without blocking.
+	///
+	/// This function, unlike `start_send` and `send`, is safe to call whether it's being called on
+	/// a task or not. Note that this function, however, will *not* attempt to block the current
+	/// task if the message cannot be sent.
+	///
+	/// It is not recommended to call this function from inside of a future, only from an external
+	/// thread where you've otherwise arranged to be notified when the channel is no longer full.
+	/// While insed a future, the `send` method should be preferred.
+	pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
+		self.channel.items.try_send(item)?;
+		// Notify the receiver, since the channel may have been empty.
+		Ok(())
+	}
+
+	/// Polls the channel to determine if there may be capacity to send at least one item without
+	/// waiting.
+	///
+	/// Returns `Ok(Async::Ready(_))` if there may be sufficient capacity, or returns
+	/// `Ok(Async::NotReady)` if the channel may not have capacity. Returns `Err(SendError(_))` if
+	/// the receiver has been dropped.
+	///
+	/// # Panics
+	///
+	/// This method will panic if called from outside the context of a task or future.
+	pub fn poll_ready(&mut self) -> Poll<(), SendError<()>> {
+		// Register the current task as the parked sender task, or if it's already been notified,
+		// then discard it.
+		let _task = self.task.take().and_then(|task| match task.register() {
+			Ok(()) => Some(task),
+			Err(()) => None,
+		});
+
+		//if false {
+		//	// There is no channel capacity available. If this sender hasn't already sent its task
+		//	// to the parked tasks channel, then do so.
+		//	let task = match task {
+		//		Some(task) => task,
+		//		None => {
+		//			let task = Arc::new(SenderTask::new());
+		//			self.channel.sender_tasks.send(task.clone()).map_err(|_| SendError(()))?;
+		//			self.channel.notify_one_receiver();
+		//			task
+		//		}
+		//	};
+		//	self.task = Some(task.clone());
+		//	Ok(Async::NotReady)
+		//} else
+		if self.channel.items.is_disconnected() {
+			Err(SendError(()))
+		} else {
+			Ok(Async::Ready(()))
+		}
+	}
+}
+
+impl<T> Sink for Sender<T> {
+	type SinkItem = T;
+	type SinkError = SendError<T>;
+
+	fn start_send(&mut self, mut item: T) -> StartSend<T, SendError<T>> {
+		loop {
+			println!("Sink polled!, attempting to send");
+			match self.try_send(item) {
+				Ok(()) => {
+					println!("Item sent!");
+					// Once we've pushed onto the channel, notify an available receiver.
+					self.channel.notify_one_receiver();
+					return Ok(AsyncSink::Ready);
+				}
+				// Try send indicated the channel is full. Call poll_ready() in order to register
+				// ourselves with the `sender_tasks` channel, and go to sleep.
+				Err(TrySendError::Full(i)) => match self.poll_ready() {
+					Ok(Async::Ready(())) => {
+						// Between the calls to try_send() and poll_ready() some capacity became
+						// available, so try to send again.
+						item = i;
+						continue;
+					}
+					Ok(Async::NotReady) => return Ok(AsyncSink::NotReady(i)),
+					Err(SendError(())) => return Err(SendError(i)),
+				},
+				Err(TrySendError::Disconnected(i)) => return Err(SendError(i)),
+			};
+		}
+	}
+
+	fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+		Ok(Async::Ready(()))
+	}
+
+	fn close(&mut self) -> Poll<(), SendError<T>> {
+		// If this Sender has a task in the parked_senders channel that has been notified, then
+		// notify another parked sender.
+		if self.task.take().map_or(false, |task| task.notify().is_err()) {
+			self.channel.notify_one_sender();
+		}
+		Ok(Async::Ready(()))
+	}
+}
+
+impl<T> Clone for Sender<T> {
+	fn clone(&self) -> Sender<T> {
+		let channel = self.channel.clone();
+		channel.senders.fetch_add(1, SeqCst);
+		Sender {
+			channel,
+			task: None,
+		}
+	}
+}
+
+impl<T> Drop for Sender<T> {
+	fn drop(&mut self) {
+		// Ensure the `Sender` is closed, which will notify another `Sender` if necessary.
+		let _ = self.close();
+		if self.channel.senders.fetch_sub(1, SeqCst) == 1 {
+			// This is the final Sender. Disconnect the channels and notify the receiver.
+			self.channel.items.disconnect();
+			self.channel.sender_tasks.disconnect();
+			// self.channel.receiver_task.notify();
+		}
+	}
+}
+
+/// The consumer, or receiver half of a futures-aware, bounded, MPSC channel.
+pub struct Receiver<T> {
+	channel: Arc<Channel<T>>,
+	task: Option<Arc<SenderTask>>,
+}
+
+unsafe impl<T: Send> Send for Receiver<T> {}
+
+unsafe impl<T: Send> Sync for Receiver<T> {}
+
+impl<T> Receiver<T> {
+	/// Closes the receiving half of the channel.
+	///
+	/// This prevents any further messages from being sent on the channel while still enabling the
+	/// receiver to drain messages that are buffered.
+	pub fn close(&mut self) {
+		self.channel.items.disconnect();
+//        self.channel.sender_tasks.disconnect();
+	}
+}
+
+impl<T> Stream for Receiver<T> {
+	type Item = T;
+	type Error = ();
+
+	fn poll(&mut self) -> Poll<Option<T>, ()> {
+		let task = match self.task.take() {
+			Some(task) => task,
+			None => Arc::new(SenderTask::new())
+		};
+		println!("Stream Polled!");
+
+		match self.channel.items.try_recv() {
+			Ok(item) => {
+				println!("Item received");
+				// Success; an item has been received. Notify a single waiting task that a
+				// slot has opened up.
+				return Ok(Async::Ready(Some(item)));
+			}
+			Err(TryRecvError::Empty) => {
+				// TODO(danburkert): figure out why this notification is necessary. The tests
+				// deadlock without it even with a single sender, but it may indicate we have a
+				// 'lost wakeup' somewhere which this papers over.
+				// register this task in `receivers_task`
+				self.channel.notify_one_sender();
+				// I believe this just keeps pushing the `task::current()` to the `recievers_taks` channel.
+				// ideally, we only want to push it once. not sure if this is the right approach.
+				self.channel.receiver_tasks
+					.send(task.clone())
+					.unwrap();
+				self.task = Some(task);
+				return Ok(Async::NotReady);
+			}
+			Err(TryRecvError::Disconnected) => {
+				// The channel has been closed. Cleanup remaining parked tasks.
+				self.channel.sender_tasks.disconnect();
+				self.channel.notify_all_senders();
+				return Ok(Async::Ready(None));
+			}
+		}
+	}
+}
+
+impl<T> Clone for Receiver<T> {
+	fn clone(&self) -> Receiver<T> {
+		let channel = self.channel.clone();
+		channel.receivers.fetch_add(1, SeqCst);
+		Receiver {
+			channel,
+			task: None,
+		}
+	}
+}
+
+impl<T> Drop for Receiver<T> {
+	fn drop(&mut self) {
+		// Disconnect the channels and notify remaining parked tasks.
+		// self.0.items.disconnect();
+		// self.0.sender_tasks.disconnect();
+		// self.0.notify_all_senders();
+
+		if self.channel.receivers.fetch_sub(1, SeqCst) == 1 {
+			// This is the final Receiver. Disconnect the channels and notify the sender.
+			self.channel.items.disconnect();
+			self.channel.sender_tasks.disconnect();
+			self.channel.receiver_tasks.disconnect();
+		}
+	}
+}

--- a/src/futures/mpsc.rs
+++ b/src/futures/mpsc.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+
+use futures_rs::{
+    Async,
+    AsyncSink,
+    Poll,
+    Sink,
+    Stream,
+    StartSend,
+};
+use futures_rs::task::AtomicTask;
+
+use flavors::{array, list};
+use err::{
+    SendError,
+    TryRecvError,
+    TrySendError,
+};
+use futures::sender_task::SenderTask;
+
+struct Channel<T> {
+    senders: AtomicUsize,
+    items: array::Channel<T>,
+    sender_tasks: list::Channel<Arc<SenderTask>>,
+    receiver_task: AtomicTask,
+}
+
+impl <T> Channel<T> {
+    fn notify_one(&self) {
+        while let Ok(sender) = self.sender_tasks.try_recv() {
+            if sender.notify().is_ok() {
+                break;
+            }
+        }
+    }
+
+    fn notify_all(&self) {
+        while let Ok(sender) = self.sender_tasks.try_recv() {
+            let _ = sender.notify();
+        }
+    }
+}
+
+/// Creates an in-memory channel implementation of the `Stream` trait with
+/// bounded capacity.
+///
+/// This method creates a concrete implementation of the `Stream` trait which
+/// can be used to send values across threads in a streaming fashion. This
+/// channel is unique in that it implements back pressure to ensure that the
+/// sender never outpaces the receiver. The channel will refuse sending new
+/// items when there are `cap` items already in-flight.
+///
+/// The `Receiver` returned implements the `Stream` trait and has access to any
+/// number of the associated combinators for transforming the result.
+pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
+    let channel = Arc::new(Channel {
+        senders: AtomicUsize::new(1),
+        items: array::Channel::with_capacity(cap),
+        sender_tasks: list::Channel::new(),
+        receiver_task: AtomicTask::new(),
+    });
+    let sender = Sender {
+        channel: channel.clone(),
+        task: None,
+    };
+    let receiver = Receiver(channel);
+    (sender, receiver)
+}
+
+pub struct Sender<T> {
+    channel: Arc<Channel<T>>,
+    task: Option<Arc<SenderTask>>,
+}
+
+unsafe impl<T: Send> Send for Sender<T> {}
+unsafe impl<T: Send> Sync for Sender<T> {}
+
+impl <T> Sender<T> {
+
+    /// Attempts to send a message on this `Sender<T>` without blocking.
+    ///
+    /// This function, unlike `start_send`, is safe to call whether it's being
+    /// called on a task or not. Note that this function, however, will *not*
+    /// attempt to block the current task if the message cannot be sent.
+    ///
+    /// It is not recommended to call this function from inside of a future,
+    /// only from an external thread where you've otherwise arranged to be
+    /// notified when the channel is no longer full.
+    pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
+        self.channel.items.try_send(item)?;
+        // Notify the receiver, since the channel may have been empty.
+        self.channel.receiver_task.notify();
+        Ok(())
+    }
+
+    /// Polls the channel to determine if there may be capacity to send at least one
+    /// item without waiting.
+    ///
+    /// Returns `Ok(Async::Ready(_))` if there may be sufficient capacity, or returns
+    /// `Ok(Async::NotReady)` if the channel may not have capacity. Returns
+    /// `Err(SendError(_))` if the receiver has been dropped.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if called from outside the context of a task or future.
+    pub fn poll_ready(&mut self) -> Poll<(), SendError<()>> {
+        // Register the current task as the parked sender task, or if it's already been notified
+        // then discard it.
+        let task = self.task.take().and_then(|task| match task.register() {
+            Ok(()) => Some(task),
+            Err(()) => None,
+        });
+
+        if self.channel.items.len() >= self.channel.items.capacity() {
+            // There's no channel capacity available. If this sender hasn't already sent its task
+            // to the parked tasks channel then do so.
+            let task = match task {
+                Some(task) => task,
+                None => {
+                    let task = Arc::new(SenderTask::new());
+                    self.channel.sender_tasks.send(task.clone()).map_err(|_| SendError(()))?;
+                    self.channel.receiver_task.notify();
+                    task
+                }
+            };
+            self.task = Some(task.clone());
+            Ok(Async::NotReady)
+        } else if self.channel.items.is_disconnected() {
+            Err(SendError(()))
+        } else {
+            Ok(Async::Ready(()))
+        }
+    }
+}
+
+impl <T> Sink for Sender<T> {
+    type SinkItem = T;
+    type SinkError = SendError<T>;
+
+    fn start_send(&mut self, mut item: T) -> StartSend<T, SendError<T>> {
+        loop {
+            match self.try_send(item) {
+                Ok(()) => return Ok(AsyncSink::Ready),
+                Err(TrySendError::Full(i)) => match self.poll_ready() {
+                    Ok(Async::Ready(())) => {
+                        item = i;
+                        continue
+                    },
+                    Ok(Async::NotReady) => return Ok(AsyncSink::NotReady(i)),
+                    Err(SendError(())) => return Err(SendError(i)),
+                },
+                Err(TrySendError::Disconnected(i)) => return Err(SendError(i)),
+            };
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
+
+    fn close(&mut self) -> Poll<(), SendError<T>> {
+        // If this Sender has a task in the parked_senders channel that has been notified, then
+        // notify another parked sender.
+        if self.task.take().map_or(false, |task| task.notify().is_err()) {
+            self.channel.notify_one();
+        }
+        Ok(Async::Ready(()))
+    }
+}
+
+impl <T> Clone for Sender<T> {
+
+    fn clone(&self) -> Sender<T> {
+        let channel = self.channel.clone();
+        channel.senders.fetch_add(1, SeqCst);
+        Sender{
+            channel,
+            task: None,
+        }
+    }
+}
+
+impl <T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        let _ = self.close();
+        if self.channel.senders.fetch_sub(1, SeqCst) == 1 {
+            // This is the final Sender. Disconnect the channels and notify the receiver.
+            self.channel.items.disconnect();
+            self.channel.sender_tasks.disconnect();
+            self.channel.receiver_task.notify();
+        }
+    }
+}
+
+pub struct Receiver<T>(Arc<Channel<T>>);
+
+unsafe impl<T: Send> Send for Receiver<T> {}
+unsafe impl<T: Send> Sync for Receiver<T> {}
+
+impl <T> Receiver<T> {
+    /// Closes the receiving half
+    ///
+    /// This prevents any further messages from being sent on the channel while
+    /// still enabling the receiver to drain messages that are buffered.
+    pub fn close(&mut self) {
+        self.0.items.disconnect();
+        self.0.sender_tasks.disconnect();
+    }
+}
+
+impl<T> Stream for Receiver<T> {
+    type Item = T;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Option<T>, ()> {
+        self.0.receiver_task.register();
+
+        match self.0.items.try_recv() {
+            Ok(item) => {
+                // Success; an item has been received. Notify a single waiting task that a
+                // slot has opened up.
+                self.0.notify_one();
+                return Ok(Async::Ready(Some(item)));
+            },
+            Err(TryRecvError::Empty) => {
+                self.0.notify_one();
+                return Ok(Async::NotReady);
+            },
+            Err(TryRecvError::Disconnected) => {
+                // The channel has been closed. Cleanup remaining parked tasks.
+                self.0.sender_tasks.disconnect();
+                self.0.notify_all();
+                return Ok(Async::Ready(None))
+            },
+        }
+    }
+}
+
+impl <T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        // Disconnect the channels and notify remaining parked tasks.
+        self.0.items.disconnect();
+        self.0.sender_tasks.disconnect();
+        self.0.notify_all();
+    }
+}

--- a/src/futures/mpsc.rs
+++ b/src/futures/mpsc.rs
@@ -20,15 +20,65 @@ use err::{
 };
 use futures::sender_task::SenderTask;
 
+
+/// The inner channel data structure shared among the senders and the receiver of a future-aware
+/// mpsc channel.
 struct Channel<T> {
+
+    /// The count of `Sender` handles outstanding. When the count reaches 0, the final `Sender`
+    /// will disconnect the `items` and `sender_tasks` channels and notify the receiver task that
+    /// the channel is no longer active.
     senders: AtomicUsize,
+
+    /// The bounded queue of items. `Sender`s push to the channel, and the `Receiver` pops items
+    /// as they become available.
     items: array::Channel<T>,
+
+    /// An unbounded queue of parked `Sender` tasks which are waiting for capacity in the `items`
+    /// channel to become available.
+    ///
+    /// ## `Sender` Usage
+    ///
+    /// During the first attempt to send an item to a channel, if the `Sender` discovers that there
+    /// is no channel capacity available, it will create a new `SenderTask`, send it to this
+    /// channel, and park itself (return `NotReady`).
+    ///
+    /// During subsequent attempts to send the item to the channel, the `Sender` will
+    /// simultaneously register it's task with the `SenderTask` and check if the `SenderTask` has
+    /// already been notified (and thus removed from the `senders_task` queue) via
+    /// `SenderTask::register`. If during this subsequent attempt to send an item there is still no
+    /// capacity, and the existing `SenderTask` has already been notified, then the `Sender` will
+    /// enqueue a a new `SenderTask` to this channel to ensure it will be notified.
+    ///
+    /// ## `Receiver` Usage
+    ///
+    /// When there is channel capacity available, the `Receiver` is responsible for dequeing sender
+    /// tasks from this channel and notifying them. The `Receiver` will notify one sender task per
+    /// item dequeued from the `items` channel.
+    ///
+    /// ## Notes on `Sender::drop`
+    ///
+    /// If a `Sender` is dropped while it has a sender task enqueued on this channel, it is
+    /// responsible for notifying an alternate sender task. This ensures that there are no 'lost
+    /// wakeups', which can occur when the `Receiver` notifies a sender task, but the sender task
+    /// is immediately dropped, or never again attempts to send an item to the channel.
     sender_tasks: list::Channel<Arc<SenderTask>>,
+
+    /// A notifier for the `Receiver`'s task.
+    ///
+    /// `Sender` instances are responsible for notifying the `Receiver` after taking any action
+    /// which the `Receiver` must wake up to handle.
+    ///
+    /// * a new item is enqueued to `items`
+    /// * a new parked sender task is enqueued to `sender_tasks`
+    /// * the final `Sender` is dropped, and the channel is disconnected
     receiver_task: AtomicTask,
 }
 
 impl <T> Channel<T> {
-    fn notify_one(&self) {
+
+    /// Notifies a single sender task that channel capacity is available.
+    fn notify_one_sender(&self) {
         while let Ok(sender) = self.sender_tasks.try_recv() {
             if sender.notify().is_ok() {
                 break;
@@ -36,24 +86,28 @@ impl <T> Channel<T> {
         }
     }
 
-    fn notify_all(&self) {
+    /// Notifies all sender tasks that the channel has been disconnected.
+    fn notify_all_senders(&self) {
+        debug_assert!(self.items.is_disconnected());
+        debug_assert!(self.sender_tasks.is_disconnected());
         while let Ok(sender) = self.sender_tasks.try_recv() {
             let _ = sender.notify();
         }
     }
 }
 
-/// Creates an in-memory channel implementation of the `Stream` trait with
-/// bounded capacity.
+/// Creates an in-memory, bounded, futures-aware MPSC channel.
 ///
-/// This method creates a concrete implementation of the `Stream` trait which
-/// can be used to send values across threads in a streaming fashion. This
-/// channel is unique in that it implements back pressure to ensure that the
-/// sender never outpaces the receiver. The channel will refuse sending new
-/// items when there are `cap` items already in-flight.
+/// This method returns `Sender` and `Receiver` instance which can be used to send values across
+/// tasks. This channel is unique in that it implements back pressure to ensure that the sender
+/// never outpaces the receiver. The channel will refuse sending new items when there are `cap`
+/// items already in-flight.
 ///
-/// The `Receiver` returned implements the `Stream` trait and has access to any
-/// number of the associated combinators for transforming the result.
+/// The `Receiver` returned implements the `Stream` trait and has access to all of the associated
+/// combinators for transforming the result.
+///
+/// The `Sender` returned implements the `Sink` trait and has access to all of the associated
+/// combinators to transform the input. `Sender` may be cloned freely and sent across tasks.
 pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     let channel = Arc::new(Channel {
         senders: AtomicUsize::new(1),
@@ -69,6 +123,7 @@ pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     (sender, receiver)
 }
 
+/// The producer, or sender half of a futures-aware, bounded, MPSC channel.
 pub struct Sender<T> {
     channel: Arc<Channel<T>>,
     task: Option<Arc<SenderTask>>,
@@ -79,15 +134,15 @@ unsafe impl<T: Send> Sync for Sender<T> {}
 
 impl <T> Sender<T> {
 
-    /// Attempts to send a message on this `Sender<T>` without blocking.
+    /// Attempts to send a message on this `Sender` without blocking.
     ///
-    /// This function, unlike `start_send`, is safe to call whether it's being
-    /// called on a task or not. Note that this function, however, will *not*
-    /// attempt to block the current task if the message cannot be sent.
+    /// This function, unlike `start_send` and `send`, is safe to call whether it's being called on
+    /// a task or not. Note that this function, however, will *not* attempt to block the current
+    /// task if the message cannot be sent.
     ///
-    /// It is not recommended to call this function from inside of a future,
-    /// only from an external thread where you've otherwise arranged to be
-    /// notified when the channel is no longer full.
+    /// It is not recommended to call this function from inside of a future, only from an external
+    /// thread where you've otherwise arranged to be notified when the channel is no longer full.
+    /// While insed a future, the `send` method should be preferred.
     pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
         self.channel.items.try_send(item)?;
         // Notify the receiver, since the channel may have been empty.
@@ -95,18 +150,18 @@ impl <T> Sender<T> {
         Ok(())
     }
 
-    /// Polls the channel to determine if there may be capacity to send at least one
-    /// item without waiting.
+    /// Polls the channel to determine if there may be capacity to send at least one item without
+    /// waiting.
     ///
     /// Returns `Ok(Async::Ready(_))` if there may be sufficient capacity, or returns
-    /// `Ok(Async::NotReady)` if the channel may not have capacity. Returns
-    /// `Err(SendError(_))` if the receiver has been dropped.
+    /// `Ok(Async::NotReady)` if the channel may not have capacity. Returns `Err(SendError(_))` if
+    /// the receiver has been dropped.
     ///
     /// # Panics
     ///
     /// This method will panic if called from outside the context of a task or future.
     pub fn poll_ready(&mut self) -> Poll<(), SendError<()>> {
-        // Register the current task as the parked sender task, or if it's already been notified
+        // Register the current task as the parked sender task, or if it's already been notified,
         // then discard it.
         let task = self.task.take().and_then(|task| match task.register() {
             Ok(()) => Some(task),
@@ -114,8 +169,8 @@ impl <T> Sender<T> {
         });
 
         if self.channel.items.len() >= self.channel.items.capacity() {
-            // There's no channel capacity available. If this sender hasn't already sent its task
-            // to the parked tasks channel then do so.
+            // There is no channel capacity available. If this sender hasn't already sent its task
+            // to the parked tasks channel, then do so.
             let task = match task {
                 Some(task) => task,
                 None => {
@@ -143,8 +198,12 @@ impl <T> Sink for Sender<T> {
         loop {
             match self.try_send(item) {
                 Ok(()) => return Ok(AsyncSink::Ready),
+                // Try send indicated the channel is full. Call poll_ready() in order to register
+                // ourselves with the `sender_tasks` channel, and go to sleep.
                 Err(TrySendError::Full(i)) => match self.poll_ready() {
                     Ok(Async::Ready(())) => {
+                        // Between the calls to try_send() and poll_ready() some capacity became
+                        // available, so try to send again.
                         item = i;
                         continue
                     },
@@ -164,7 +223,7 @@ impl <T> Sink for Sender<T> {
         // If this Sender has a task in the parked_senders channel that has been notified, then
         // notify another parked sender.
         if self.task.take().map_or(false, |task| task.notify().is_err()) {
-            self.channel.notify_one();
+            self.channel.notify_one_sender();
         }
         Ok(Async::Ready(()))
     }
@@ -184,6 +243,7 @@ impl <T> Clone for Sender<T> {
 
 impl <T> Drop for Sender<T> {
     fn drop(&mut self) {
+        // Ensure the `Sender` is closed, which will notify another `Sender` if necessary.
         let _ = self.close();
         if self.channel.senders.fetch_sub(1, SeqCst) == 1 {
             // This is the final Sender. Disconnect the channels and notify the receiver.
@@ -194,16 +254,17 @@ impl <T> Drop for Sender<T> {
     }
 }
 
+/// The consumer, or receiver half of a futures-aware, bounded, MPSC channel.
 pub struct Receiver<T>(Arc<Channel<T>>);
 
 unsafe impl<T: Send> Send for Receiver<T> {}
 unsafe impl<T: Send> Sync for Receiver<T> {}
 
 impl <T> Receiver<T> {
-    /// Closes the receiving half
+    /// Closes the receiving half of the channel.
     ///
-    /// This prevents any further messages from being sent on the channel while
-    /// still enabling the receiver to drain messages that are buffered.
+    /// This prevents any further messages from being sent on the channel while still enabling the
+    /// receiver to drain messages that are buffered.
     pub fn close(&mut self) {
         self.0.items.disconnect();
         self.0.sender_tasks.disconnect();
@@ -221,17 +282,20 @@ impl<T> Stream for Receiver<T> {
             Ok(item) => {
                 // Success; an item has been received. Notify a single waiting task that a
                 // slot has opened up.
-                self.0.notify_one();
+                self.0.notify_one_sender();
                 return Ok(Async::Ready(Some(item)));
             },
             Err(TryRecvError::Empty) => {
-                self.0.notify_one();
+                // TODO(danburkert): figure out why this notification is necessary. The tests
+                // deadlock without it even with a single sender, but it may indicate we have a
+                // 'lost wakeup' somewhere which this papers over.
+                self.0.notify_one_sender();
                 return Ok(Async::NotReady);
             },
             Err(TryRecvError::Disconnected) => {
                 // The channel has been closed. Cleanup remaining parked tasks.
                 self.0.sender_tasks.disconnect();
-                self.0.notify_all();
+                self.0.notify_all_senders();
                 return Ok(Async::Ready(None))
             },
         }
@@ -243,6 +307,6 @@ impl <T> Drop for Receiver<T> {
         // Disconnect the channels and notify remaining parked tasks.
         self.0.items.disconnect();
         self.0.sender_tasks.disconnect();
-        self.0.notify_all();
+        self.0.notify_all_senders();
     }
 }

--- a/src/futures/sender_task.rs
+++ b/src/futures/sender_task.rs
@@ -1,0 +1,81 @@
+use std::cell::UnsafeCell;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{Acquire, Release};
+
+use futures_rs::task::{self, Task};
+
+/// A synchronization mechanism between senders and notifiers.
+///
+/// Based on `futures::AtomicTask`.
+pub struct SenderTask {
+    state: AtomicUsize,
+    task: UnsafeCell<Task>,
+}
+
+/// Initial state.
+const NOTIFIED_BIT: usize = 1;
+const LOCKED_BIT: usize = 1 << 1;
+
+const PARKED: usize = 0;
+const LOCKED: usize = LOCKED_BIT;
+const NOTIFIED: usize = NOTIFIED_BIT;
+const LOCKED_NOTIFIED: usize = LOCKED_BIT | NOTIFIED_BIT;
+
+impl SenderTask {
+
+    /// Create a new `SenderTask` initialized with the current task.
+    pub fn new() -> SenderTask {
+        SenderTask {
+            state: AtomicUsize::new(PARKED),
+            task: UnsafeCell::new(task::current()),
+        }
+    }
+
+    /// Registers the current task to be notified on calls to `notify`.
+    ///
+    /// Must only be called by the sender.
+    ///
+    /// If the sender task has already been notified, an error is returned.
+    pub fn register(&self) -> Result<(), ()> {
+        // Get a new task handle
+        let task = task::current();
+
+        match self.state.fetch_or(LOCKED_BIT, Acquire) {
+            PARKED => unsafe {
+                // Lock acquired, update the task cell.
+                *self.task.get() = task;
+
+                // Release the lock. If the state transitioned to
+                // `NOTIFIED`, this means that a notify has been
+                // signaled, so return an error.
+                if self.state.fetch_and(!LOCKED_BIT, Release) & NOTIFIED_BIT > 0 {
+                    Err(())
+                } else {
+                    Ok(())
+                }
+            },
+            _ => Err(())
+        }
+    }
+
+    /// Notifies the sender task.
+    ///
+    /// If the sender task has already been notified, an error is returned.
+    pub fn notify(&self) -> Result<(), ()> {
+        let state = self.state.fetch_or(NOTIFIED_BIT, Acquire);
+        if state == PARKED {
+            unsafe {
+                (*self.task.get()).notify();
+            }
+        }
+        if state == PARKED || state == LOCKED {
+            Ok(())
+        } else {
+            debug_assert!(state == NOTIFIED || state == LOCKED_NOTIFIED);
+            Err(())
+        }
+    }
+}
+
+unsafe impl Send for SenderTask {}
+unsafe impl Sync for SenderTask {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ extern crate crossbeam_epoch;
 extern crate crossbeam_utils;
 extern crate parking_lot;
 
-#[cfg(feature="futures")]
+//#[cfg(feature="futures")]
 extern crate futures as futures_rs;
 
 mod channel;
@@ -344,5 +344,5 @@ pub use err::{SendError, SendTimeoutError, TrySendError};
 pub use err::{SelectRecvError, SelectSendError};
 pub use select::Select;
 
-#[cfg(feature="futures")]
+//#[cfg(feature="futures")]
 pub mod futures;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,9 @@ extern crate crossbeam_epoch;
 extern crate crossbeam_utils;
 extern crate parking_lot;
 
+#[cfg(feature="futures")]
+extern crate futures as futures_rs;
+
 mod channel;
 mod err;
 mod exchanger;
@@ -340,3 +343,6 @@ pub use err::{RecvError, RecvTimeoutError, TryRecvError};
 pub use err::{SendError, SendTimeoutError, TrySendError};
 pub use err::{SelectRecvError, SelectSendError};
 pub use select::Select;
+
+#[cfg(feature="futures")]
+pub mod futures;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -22,7 +22,7 @@ struct Case {
 
 /// A simple wait queue for list-based and array-based channels.
 ///
-/// This data structure is used sfor registeroing selection cases before blocking and waking them
+/// This data structure is used for registering selection cases before blocking and waking them
 /// up when the channel receives a message, sends one, or becomes disconnected.
 pub struct Monitor {
     /// The list of registered selection cases.

--- a/tests/futures.rs
+++ b/tests/futures.rs
@@ -1,0 +1,351 @@
+#![cfg(feature="futures")]
+
+extern crate crossbeam_channel;
+extern crate futures;
+
+use std::time::Duration;
+use std::thread;
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crossbeam_channel::futures::mpsc;
+
+use futures::prelude::*;
+use futures::future::lazy;
+
+trait AssertSend: Send {}
+impl AssertSend for mpsc::Sender<i32> {}
+impl AssertSend for mpsc::Receiver<i32> {}
+
+pub trait ForgetExt {
+    fn forget(self);
+}
+
+impl<F> ForgetExt for F
+    where F: Future + Sized + Send + 'static,
+          F::Item: Send,
+          F::Error: Send
+{
+    fn forget(self) {
+        thread::spawn(|| self.wait());
+    }
+}
+
+#[test]
+fn send_recv() {
+    let (tx, rx) = mpsc::channel::<i32>(16);
+    let mut rx = rx.wait();
+
+    tx.send(1).wait().unwrap();
+
+    assert_eq!(rx.next().unwrap(), Ok(1));
+}
+
+#[test]
+fn send_recv_no_buffer() {
+    //let (mut tx, mut rx) = mpsc::channel::<i32>(0);
+    let (mut tx, mut rx) = mpsc::channel::<i32>(1);
+
+    // Run on a task context
+    lazy(move || {
+        assert!(tx.poll_ready().unwrap().is_ready());
+
+        // Send first message
+        tx.try_send(1).unwrap();
+        assert!(tx.poll_ready().unwrap().is_not_ready());
+
+        // Send second message
+        assert!(tx.try_send(2).is_err());
+
+        // Take the value
+        assert_eq!(rx.poll().unwrap(), Async::Ready(Some(1)));
+        assert!(tx.poll_ready().unwrap().is_ready());
+
+        tx.try_send(2).unwrap();
+        assert!(tx.poll_ready().unwrap().is_not_ready());
+
+        // Take the value
+        assert_eq!(rx.poll().unwrap(), Async::Ready(Some(2)));
+        assert!(tx.poll_ready().unwrap().is_ready());
+
+        Ok::<(), ()>(())
+    }).wait().unwrap();
+}
+
+#[test]
+fn send_shared_recv() {
+    let (tx1, rx) = mpsc::channel::<i32>(16);
+    let tx2 = tx1.clone();
+    let mut rx = rx.wait();
+
+    tx1.send(1).wait().unwrap();
+    assert_eq!(rx.next().unwrap(), Ok(1));
+
+    tx2.send(2).wait().unwrap();
+    assert_eq!(rx.next().unwrap(), Ok(2));
+}
+
+#[test]
+fn send_recv_threads() {
+    let (tx, rx) = mpsc::channel::<i32>(16);
+    let mut rx = rx.wait();
+
+    thread::spawn(move|| {
+        tx.send(1).wait().unwrap();
+    });
+
+    assert_eq!(rx.next().unwrap(), Ok(1));
+}
+
+#[test]
+fn send_recv_threads_no_capacity() {
+    let (mut tx, rx) = mpsc::channel::<i32>(1);
+    let mut rx = rx.wait();
+
+    let t = thread::spawn(move|| {
+        tx = tx.send(1).wait().unwrap();
+        tx = tx.send(2).wait().unwrap();
+    });
+
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(rx.next().unwrap(), Ok(1));
+
+    thread::sleep(Duration::from_millis(100));
+    assert_eq!(rx.next().unwrap(), Ok(2));
+
+    t.join().unwrap();
+}
+
+#[test]
+fn recv_close_gets_none() {
+    let (mut tx, mut rx) = mpsc::channel::<i32>(10);
+
+    // Run on a task context
+    lazy(move || {
+        rx.close();
+
+        assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+        assert!(tx.poll_ready().is_err());
+
+        drop(tx);
+
+        Ok::<(), ()>(())
+    }).wait().unwrap();
+}
+
+
+#[test]
+fn tx_close_gets_none() {
+    let (_, mut rx) = mpsc::channel::<i32>(10);
+
+    // Run on a task context
+    lazy(move || {
+        assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+        assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+
+        Ok::<(), ()>(())
+    }).wait().unwrap();
+}
+
+#[test]
+fn stress_shared_bounded_hard() {
+    const AMT: u32 = 5000;
+    const NTHREADS: u32 = 8;
+    let (tx, rx) = mpsc::channel::<i32>(1);
+    let mut rx = rx.wait();
+
+    let t = thread::spawn(move|| {
+        for _ in 0..AMT * NTHREADS {
+            assert_eq!(rx.next().unwrap(), Ok(1));
+        }
+
+        if rx.next().is_some() {
+            panic!();
+        }
+    });
+
+    for _ in 0..NTHREADS {
+        let mut tx = tx.clone();
+
+        thread::spawn(move|| {
+            for _ in 0..AMT {
+                tx = tx.send(1).wait().unwrap();
+            }
+        });
+    }
+
+    drop(tx);
+
+    t.join().ok().unwrap();
+}
+
+#[test]
+fn stress_receiver_multi_task_bounded_hard() {
+    const AMT: usize = 10_000;
+    const NTHREADS: u32 = 2;
+
+    let (mut tx, rx) = mpsc::channel::<usize>(1);
+    let rx = Arc::new(Mutex::new(Some(rx)));
+    let n = Arc::new(AtomicUsize::new(0));
+
+    let mut th = vec![];
+
+    for _ in 0..NTHREADS {
+        let rx = rx.clone();
+        let n = n.clone();
+
+        let t = thread::spawn(move || {
+            let mut i = 0;
+
+            loop {
+                i += 1;
+                let mut lock = rx.lock().ok().unwrap();
+
+                match lock.take() {
+                    Some(mut rx) => {
+                        if i % 5 == 0 {
+                            let (item, rest) = rx.into_future().wait().ok().unwrap();
+
+                            if item.is_none() {
+                                break;
+                            }
+
+                            n.fetch_add(1, Ordering::Relaxed);
+                            *lock = Some(rest);
+                        } else {
+                            // Just poll
+                            let n = n.clone();
+                            let r = lazy(move || {
+                                let r = match rx.poll().unwrap() {
+                                    Async::Ready(Some(_)) => {
+                                        n.fetch_add(1, Ordering::Relaxed);
+                                        *lock = Some(rx);
+                                        false
+                                    }
+                                    Async::Ready(None) => {
+                                        true
+                                    }
+                                    Async::NotReady => {
+                                        *lock = Some(rx);
+                                        false
+                                    }
+                                };
+
+                                Ok::<bool, ()>(r)
+                            }).wait().unwrap();
+
+                            if r {
+                                break;
+                            }
+                        }
+                    }
+                    None => break,
+                }
+            }
+        });
+
+        th.push(t);
+    }
+
+    for i in 0..AMT {
+        tx = tx.send(i).wait().unwrap();
+    }
+
+    drop(tx);
+
+    for t in th {
+        t.join().unwrap();
+    }
+
+    assert_eq!(AMT, n.load(Ordering::Relaxed));
+}
+
+/// Stress test that receiver properly receives all the messages
+/// after sender dropped.
+#[test]
+fn stress_drop_sender() {
+    fn list() -> Box<Stream<Item=i32, Error=u32>> {
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(Ok(1))
+          .and_then(|tx| tx.send(Ok(2)))
+          .and_then(|tx| tx.send(Ok(3)))
+          .forget();
+        Box::new(rx.then(|r| r.unwrap()))
+    }
+
+    for _ in 0..1000 {
+        assert_eq!(list().wait().collect::<Result<Vec<_>, _>>(),
+                   Ok(vec![1, 2, 3]));
+        eprintln!("done!");
+    }
+}
+
+#[test]
+fn try_send_1() {
+    const N: usize = 3000;
+    let (mut tx, rx) = mpsc::channel(1);
+
+    let t = thread::spawn(move || {
+        for i in 0..N {
+            loop {
+                if tx.try_send(i).is_ok() {
+                    break
+                }
+            }
+        }
+    });
+    for (i, j) in rx.wait().enumerate() {
+        assert_eq!(i, j.unwrap());
+    }
+    t.join().unwrap();
+}
+
+#[test]
+fn try_send_2() {
+    use std::thread;
+    use std::time::Duration;
+
+    let (mut tx, rx) = mpsc::channel(1);
+
+    tx.try_send("hello").unwrap();
+
+    let th = thread::spawn(|| {
+        lazy(|| {
+            assert!(tx.try_send("fail").is_err());
+            Ok::<_, ()>(())
+        }).wait().unwrap();
+
+        tx.send("goodbye").wait().unwrap();
+    });
+
+    // Little sleep to hopefully get the action on the thread to happen first
+    thread::sleep(Duration::from_millis(300));
+
+    let mut rx = rx.wait();
+
+    assert_eq!(rx.next(), Some(Ok("hello")));
+    assert_eq!(rx.next(), Some(Ok("goodbye")));
+    assert!(rx.next().is_none());
+
+    th.join().unwrap();
+}
+
+#[test]
+fn try_send_fail() {
+    //let (mut tx, rx) = mpsc::channel(0);
+    let (mut tx, rx) = mpsc::channel(1);
+    let mut rx = rx.wait();
+
+    tx.try_send("hello").unwrap();
+
+    // This should fail
+    assert!(tx.try_send("fail").is_err());
+
+    assert_eq!(rx.next(), Some(Ok("hello")));
+
+    tx.try_send("goodbye").unwrap();
+    drop(tx);
+
+    assert_eq!(rx.next(), Some(Ok("goodbye")));
+    assert!(rx.next().is_none());
+}

--- a/tests/futures_mpmc.rs
+++ b/tests/futures_mpmc.rs
@@ -1,0 +1,385 @@
+// #![cfg(feature="futures")]
+
+extern crate crossbeam_channel;
+extern crate futures;
+
+use std::time::Duration;
+use std::thread;
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crossbeam_channel::futures::mpmc;
+
+use futures::prelude::*;
+use futures::future::lazy;
+
+trait AssertSend: Send {}
+impl AssertSend for mpmc::Sender<i32> {}
+impl AssertSend for mpmc::Receiver<i32> {}
+
+pub trait ForgetExt {
+    fn forget(self);
+}
+
+impl<F> ForgetExt for F
+    where F: Future + Sized + Send + 'static,
+          F::Item: Send,
+          F::Error: Send
+{
+    fn forget(self) {
+        thread::spawn(|| self.wait());
+    }
+}
+
+#[test]
+fn send_recv() {
+    let (tx, rx) = mpmc::channel::<i32>();
+    let mut rx = rx.wait();
+
+    tx.send(1).wait().unwrap();
+
+    assert_eq!(rx.next().unwrap(), Ok(1));
+}
+
+#[test]
+fn send_recv_shared() {
+	let (tx, rx) = mpmc::channel::<i32>();
+	let clone1 = rx.clone();
+	let clone2 = rx.clone();
+
+	thread::spawn(move || {
+		let rx = clone1.clone();
+		let mut rx = rx.wait();
+		for item in rx {
+			println!("[thread1]: Got Item {:?}", &item);
+			assert!(true);
+		}
+	});
+
+	thread::spawn(move || {
+		let rx = clone2.clone();
+		let mut rx = rx.wait();
+		for item in rx {
+			println!("[thread2]: Got Item {:?}", &item);
+			assert!(true);
+		}
+	});
+
+	tx.send(1)
+		.and_then(|tx| tx.send(2))
+		.and_then(|tx| tx.send(3))
+		.and_then(|tx| tx.send(4))
+		.and_then(|tx| tx.send(5))
+		.and_then(|tx| tx.send(6))
+		.wait()
+		.unwrap();
+}
+
+// #[test]
+// fn send_recv_no_buffer() {
+//     //let (mut tx, mut rx) = mpmc::channel::<i32>(0);
+//     let (mut tx, mut rx) = mpmc::channel::<i32>(1);
+
+//     // Run on a task context
+//     lazy(move || {
+//         assert!(tx.poll_ready().unwrap().is_ready());
+
+//         // Send first message
+//         tx.try_send(1).unwrap();
+//         assert!(tx.poll_ready().unwrap().is_not_ready());
+
+//         // Send second message
+//         assert!(tx.try_send(2).is_err());
+
+//         // Take the value
+//         assert_eq!(rx.poll().unwrap(), Async::Ready(Some(1)));
+//         assert!(tx.poll_ready().unwrap().is_ready());
+
+//         tx.try_send(2).unwrap();
+//         assert!(tx.poll_ready().unwrap().is_not_ready());
+
+//         // Take the value
+//         assert_eq!(rx.poll().unwrap(), Async::Ready(Some(2)));
+//         assert!(tx.poll_ready().unwrap().is_ready());
+
+//         Ok::<(), ()>(())
+//     }).wait().unwrap();
+// }
+
+ #[test]
+ fn send_shared_recv() {
+     let (tx1, rx) = mpmc::channel::<i32>();
+     let tx2 = tx1.clone();
+     let mut rx = rx.wait();
+
+     tx1.send(1).wait().unwrap();
+     assert_eq!(rx.next().unwrap(), Ok(1));
+
+     tx2.send(2).wait().unwrap();
+     assert_eq!(rx.next().unwrap(), Ok(2));
+ }
+
+ #[test]
+ fn send_recv_threads() {
+     let (tx, rx) = mpmc::channel::<i32>();
+     let mut rx = rx.wait();
+
+     thread::spawn(move|| {
+         tx.send(1).wait().unwrap();
+     });
+
+     assert_eq!(rx.next().unwrap(), Ok(1));
+ }
+
+ #[test]
+ fn send_recv_threads_no_capacity() {
+     let (mut tx, rx) = mpmc::channel::<i32>();
+     let mut rx = rx.wait();
+
+     let t = thread::spawn(move|| {
+         tx = tx.send(1).wait().unwrap();
+         tx = tx.send(2).wait().unwrap();
+     });
+
+     thread::sleep(Duration::from_millis(100));
+     assert_eq!(rx.next().unwrap(), Ok(1));
+
+     thread::sleep(Duration::from_millis(100));
+     assert_eq!(rx.next().unwrap(), Ok(2));
+
+     t.join().unwrap();
+ }
+
+ #[test]
+ fn recv_close_gets_none() {
+     let (mut tx, mut rx) = mpmc::channel::<i32>();
+
+     // Run on a task context
+     lazy(move || {
+         rx.close();
+
+         assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+         assert!(tx.poll_ready().is_err());
+
+         drop(tx);
+
+         Ok::<(), ()>(())
+     }).wait().unwrap();
+ }
+
+
+ #[test]
+ fn tx_close_gets_none() {
+     let (_, mut rx) = mpmc::channel::<i32>();
+
+     // Run on a task context
+     lazy(move || {
+         assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+         assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+
+         Ok::<(), ()>(())
+     }).wait().unwrap();
+ }
+
+ #[test]
+ fn stress_shared_bounded_hard() {
+     const AMT: u32 = 5000;
+     const NTHREADS: u32 = 8;
+     let (tx, rx) = mpmc::channel::<i32>();
+     let mut rx = rx.wait();
+
+     let t = thread::spawn(move|| {
+         for _ in 0..AMT * NTHREADS {
+             assert_eq!(rx.next().unwrap(), Ok(1));
+         }
+
+         if rx.next().is_some() {
+             panic!();
+         }
+     });
+
+     for _ in 0..NTHREADS {
+         let mut tx = tx.clone();
+
+         thread::spawn(move|| {
+             for _ in 0..AMT {
+                 tx = tx.send(1).wait().unwrap();
+             }
+         });
+     }
+
+     drop(tx);
+
+     t.join().ok().unwrap();
+ }
+
+// #[test]
+// fn stress_receiver_multi_task_bounded_hard() {
+//     const AMT: usize = 10_000;
+//     const NTHREADS: u32 = 2;
+
+//     let (mut tx, rx) = mpmc::channel::<usize>(1);
+//     let rx = Arc::new(Mutex::new(Some(rx)));
+//     let n = Arc::new(AtomicUsize::new(0));
+
+//     let mut th = vec![];
+
+//     for _ in 0..NTHREADS {
+//         let rx = rx.clone();
+//         let n = n.clone();
+
+//         let t = thread::spawn(move || {
+//             let mut i = 0;
+
+//             loop {
+//                 i += 1;
+//                 let mut lock = rx.lock().ok().unwrap();
+
+//                 match lock.take() {
+//                     Some(mut rx) => {
+//                         if i % 5 == 0 {
+//                             let (item, rest) = rx.into_future().wait().ok().unwrap();
+
+//                             if item.is_none() {
+//                                 break;
+//                             }
+
+//                             n.fetch_add(1, Ordering::Relaxed);
+//                             *lock = Some(rest);
+//                         } else {
+//                             // Just poll
+//                             let n = n.clone();
+//                             let r = lazy(move || {
+//                                 let r = match rx.poll().unwrap() {
+//                                     Async::Ready(Some(_)) => {
+//                                         n.fetch_add(1, Ordering::Relaxed);
+//                                         *lock = Some(rx);
+//                                         false
+//                                     }
+//                                     Async::Ready(None) => {
+//                                         true
+//                                     }
+//                                     Async::NotReady => {
+//                                         *lock = Some(rx);
+//                                         false
+//                                     }
+//                                 };
+
+//                                 Ok::<bool, ()>(r)
+//                             }).wait().unwrap();
+
+//                             if r {
+//                                 break;
+//                             }
+//                         }
+//                     }
+//                     None => break,
+//                 }
+//             }
+//         });
+
+//         th.push(t);
+//     }
+
+//     for i in 0..AMT {
+//         tx = tx.send(i).wait().unwrap();
+//     }
+
+//     drop(tx);
+
+//     for t in th {
+//         t.join().unwrap();
+//     }
+
+//     assert_eq!(AMT, n.load(Ordering::Relaxed));
+// }
+
+// /// Stress test that receiver properly receives all the messages
+// /// after sender dropped.
+// #[test]
+// fn stress_drop_sender() {
+//     fn list() -> Box<Stream<Item=i32, Error=u32>> {
+//         let (tx, rx) = mpmc::channel();
+//         tx.send(Ok(1))
+//           .and_then(|tx| tx.send(Ok(2)))
+//           .and_then(|tx| tx.send(Ok(3)))
+//           .forget();
+//         Box::new(rx.then(|r| r.unwrap()))
+//     }
+//
+//     for _ in 0..1000 {
+//         assert_eq!(list().wait().collect::<Result<Vec<_>, _>>(),
+//                    Ok(vec![1, 2, 3]));
+//         eprintln!("done!");
+//     }
+// }
+
+// #[test]
+// fn try_send_1() {
+//     const N: usize = 3000;
+//     let (mut tx, rx) = mpmc::channel(1);
+
+//     let t = thread::spawn(move || {
+//         for i in 0..N {
+//             loop {
+//                 if tx.try_send(i).is_ok() {
+//                     break
+//                 }
+//             }
+//         }
+//     });
+//     for (i, j) in rx.wait().enumerate() {
+//         assert_eq!(i, j.unwrap());
+//     }
+//     t.join().unwrap();
+// }
+
+// #[test]
+// fn try_send_2() {
+//     use std::thread;
+//     use std::time::Duration;
+
+//     let (mut tx, rx) = mpmc::channel(1);
+
+//     tx.try_send("hello").unwrap();
+
+//     let th = thread::spawn(|| {
+//         lazy(|| {
+//             assert!(tx.try_send("fail").is_err());
+//             Ok::<_, ()>(())
+//         }).wait().unwrap();
+
+//         tx.send("goodbye").wait().unwrap();
+//     });
+
+//     // Little sleep to hopefully get the action on the thread to happen first
+//     thread::sleep(Duration::from_millis(300));
+
+//     let mut rx = rx.wait();
+
+//     assert_eq!(rx.next(), Some(Ok("hello")));
+//     assert_eq!(rx.next(), Some(Ok("goodbye")));
+//     assert!(rx.next().is_none());
+
+//     th.join().unwrap();
+// }
+
+// #[test]
+// fn try_send_fail() {
+//     //let (mut tx, rx) = mpmc::channel(0);
+//     let (mut tx, rx) = mpmc::channel(1);
+//     let mut rx = rx.wait();
+
+//     tx.try_send("hello").unwrap();
+
+//     // This should fail
+//     assert!(tx.try_send("fail").is_err());
+
+//     assert_eq!(rx.next(), Some(Ok("hello")));
+
+//     tx.try_send("goodbye").unwrap();
+//     drop(tx);
+
+//     assert_eq!(rx.next(), Some(Ok("goodbye")));
+//     assert!(rx.next().is_none());
+// }


### PR DESCRIPTION
- [x] naive implementation of an unbounded futures aware mpmc channel.

notes:
I've tested this [here](https://github.com/SeunLanLege/arc-reactor/blob/futures-mpmc/src/ArcCore/reactor.rs)(yes I actually have a need for an mpmc futures channel) and it works for the *most* part.

https://github.com/SeunLanLege/arc-reactor/blob/futures-mpmc/src/ArcCore/reactor.rs#L64-L139

A lot of work still needs to be done, as regards to drop semantics and a more efficient approach to task notification. plus there's a lot i don't understand like:
1.why we need to track a task's notification state? or maybe i don't fully understand what tasks really are. :cry: 

but yeah, pointers are welcome.