### PR TITLE
Document select_loop!'s looping even more explicitly

### DIFF
--- a/src/select/select_loop.rs
+++ b/src/select/select_loop.rs
@@ -7,7 +7,8 @@
 /// # What is selection?
 ///
 /// It is possible to declare a set of possible send and/or receive operations on channels, and
-/// then wait until exactly one of them fires (in other words, one of them is *selected*).
+/// then wait until exactly one of them fires (in other words, one of them is *selected*). Once the
+/// selected operation fires, the loop is broken.
 ///
 /// For example, we might want to receive a message from a set of two channels and block until a
 /// message is received from any of them. To do that, we would write:


### PR DESCRIPTION
I was confused by `select_loop!`.  I thought that the "loop" in its name meant
it would keep iterating, continually matching and making selections.

I read the documentation several times, but somehow missed it saying the loop
is exited after the first selection is made.

It was only after some time that I found #27 which cleared up my confusion.
Hopefully these changes will help people avoid that problem in the future.


(It may actually be a good idea to include `select_loop!`s etymology as
described in:
https://github.com/crossbeam-rs/crossbeam-channel/issues/27#issuecomment-356903223
that comment really cleared things up for me.  I just didn't see an obvious
location to add it to the existing documentation.)