### PR TITLE
Fix the select! macro when used with #![deny(unsafe_code)]

### DIFF
--- a/src/internal/codegen.rs
+++ b/src/internal/codegen.rs
@@ -469,6 +469,7 @@ macro_rules! __crossbeam_channel_codegen {
         $default:tt
     ) => {
         if $index == $i {
+            #[allow(unsafe_code)]
             let ($m, $r) = unsafe {
                 let r = $crate::internal::codegen::deref_from_iterator(
                     $selected as *const $crate::Receiver<_>,
@@ -503,6 +504,7 @@ macro_rules! __crossbeam_channel_codegen {
             let $s = {
                 // We have to prefix variables with an underscore to get rid of warnings when
                 // evaluation of `$m` doesn't finish.
+                #[allow(unsafe_code)]
                 let _s = unsafe {
                     $crate::internal::codegen::deref_from_iterator(
                         $selected as *const $crate::Sender<_>,
@@ -517,6 +519,7 @@ macro_rules! __crossbeam_channel_codegen {
                 #[allow(unreachable_code)]
                 {
                     ::std::mem::forget(_guard);
+                    #[allow(unsafe_code)]
                     unsafe { $crate::internal::channel::write(_s, &mut $token, _msg); }
                     _s
                 }

--- a/tests/select.rs
+++ b/tests/select.rs
@@ -1,5 +1,7 @@
 //! Tests for the `select!` macro.
 
+#![deny(unsafe_code)]
+
 extern crate crossbeam;
 #[macro_use]
 extern crate crossbeam_channel as channel;


### PR DESCRIPTION
Unfortunately, `macro_rules!` seems not to be hygienic with respect to lints.