### PR TITLE
Drop select handles early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Ignore clippy warnings in `select!`.
+- Better interaction of `select!` with the NLL borrow checker.
 
 ## [0.2.1] - 2018-06-12
 ### Changed


### PR DESCRIPTION
This change allows the following code to compile:

```rust
#![feature(nll)]

#[macro_use]
extern crate crossbeam_channel as channel;

fn main() {
    let (s, r) = channel::unbounded::<channel::Receiver<i32>>();
    let mut channels = vec![];

    select! {
        recv(r, msg, y) => channels.push(y.clone()),
        recv(channels, y, from) => {}
    }
}
```

cc #50 