### PR TITLE
Remove Mac OS X tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: rust
 
-os:
-  - linux
-  - osx
-
 rust:
   - stable
   - beta

--- a/src/internal/channel.rs
+++ b/src/internal/channel.rs
@@ -173,16 +173,16 @@ pub fn bounded<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// let ms = |ms| Duration::from_millis(ms);
 ///
 /// // Returns `true` if `a` and `b` are very close `Instant`s.
-/// let eq = |a, b| a + ms(100) > b && b + ms(100) > a;
+/// let eq = |a, b| a + ms(50) > b && b + ms(50) > a;
 ///
 /// let start = Instant::now();
-/// let r = channel::after(ms(200));
+/// let r = channel::after(ms(100));
 ///
-/// thread::sleep(ms(1000));
+/// thread::sleep(ms(500));
 ///
-/// // This message was sent 200 ms from the start and received 1000 ms from the start.
-/// assert!(eq(r.recv().unwrap(), start + ms(200)));
-/// assert!(eq(Instant::now(), start + ms(1000)));
+/// // This message was sent 100 ms from the start and received 500 ms from the start.
+/// assert!(eq(r.recv().unwrap(), start + ms(100)));
+/// assert!(eq(Instant::now(), start + ms(500)));
 /// ```
 pub fn after(duration: Duration) -> Receiver<Instant> {
     Receiver(ReceiverFlavor::After(flavors::after::Channel::new(duration)))
@@ -206,24 +206,24 @@ pub fn after(duration: Duration) -> Receiver<Instant> {
 /// let ms = |ms| Duration::from_millis(ms);
 ///
 /// // Returns `true` if `a` and `b` are very close `Instant`s.
-/// let eq = |a, b| a + ms(100) > b && b + ms(100) > a;
+/// let eq = |a, b| a + ms(50) > b && b + ms(50) > a;
 ///
 /// let start = Instant::now();
-/// let r = channel::tick(ms(200));
+/// let r = channel::tick(ms(100));
 ///
-/// // This message was sent 200 ms from the start and received 200 ms from the start.
-/// assert!(eq(r.recv().unwrap(), start + ms(200)));
-/// assert!(eq(Instant::now(), start + ms(200)));
+/// // This message was sent 100 ms from the start and received 100 ms from the start.
+/// assert!(eq(r.recv().unwrap(), start + ms(100)));
+/// assert!(eq(Instant::now(), start + ms(100)));
 ///
 /// thread::sleep(ms(500));
 ///
-/// // This message was sent 400 ms from the start and received 700 ms from the start.
-/// assert!(eq(r.recv().unwrap(), start + ms(400)));
-/// assert!(eq(Instant::now(), start + ms(700)));
+/// // This message was sent 200 ms from the start and received 600 ms from the start.
+/// assert!(eq(r.recv().unwrap(), start + ms(200)));
+/// assert!(eq(Instant::now(), start + ms(600)));
 ///
-/// // This message was sent 900 ms from the start and received 900 ms from the start.
-/// assert!(eq(r.recv().unwrap(), start + ms(900)));
-/// assert!(eq(Instant::now(), start + ms(900)));
+/// // This message was sent 700 ms from the start and received 700 ms from the start.
+/// assert!(eq(r.recv().unwrap(), start + ms(700)));
+/// assert!(eq(Instant::now(), start + ms(700)));
 /// ```
 pub fn tick(duration: Duration) -> Receiver<Instant> {
     Receiver(ReceiverFlavor::Tick(flavors::tick::Channel::new(duration)))

--- a/tests/after.rs
+++ b/tests/after.rs
@@ -24,18 +24,18 @@ macro_rules! tests {
         #[test]
         fn fire() {
             let start = Instant::now();
-            let r = channel::after(ms(100));
+            let r = channel::after(ms(50));
 
             assert_eq!(r.try_recv(), None);
-            thread::sleep(ms(200));
+            thread::sleep(ms(100));
 
             let fired = r.try_recv().unwrap();
             assert!(start < fired);
-            assert!(fired - start >= ms(100));
+            assert!(fired - start >= ms(50));
 
             let now = Instant::now();
             assert!(fired < now);
-            assert!(now - fired >= ms(100));
+            assert!(now - fired >= ms(50));
 
             assert_eq!(r.try_recv(), None);
 
@@ -46,7 +46,7 @@ macro_rules! tests {
 
             select! {
                 recv(r) => panic!(),
-                recv(channel::after(ms(400))) => {}
+                recv(channel::after(ms(200))) => {}
             }
         }
 
@@ -62,13 +62,13 @@ macro_rules! tests {
 
         #[test]
         fn len_empty_full() {
-            let r = channel::after(ms(100));
+            let r = channel::after(ms(50));
 
             assert_eq!(r.len(), 0);
             assert_eq!(r.is_empty(), true);
             assert_eq!(r.is_full(), false);
 
-            thread::sleep(ms(200));
+            thread::sleep(ms(100));
 
             assert_eq!(r.len(), 1);
             assert_eq!(r.is_empty(), false);
@@ -84,11 +84,11 @@ macro_rules! tests {
         #[test]
         fn recv() {
             let start = Instant::now();
-            let r = channel::after(ms(100));
+            let r = channel::after(ms(50));
 
             let fired = r.recv().unwrap();
             assert!(start < fired);
-            assert!(fired - start >= ms(100));
+            assert!(fired - start >= ms(50));
 
             let now = Instant::now();
             assert!(fired < now);
@@ -99,8 +99,8 @@ macro_rules! tests {
 
         #[test]
         fn recv_two() {
-            let r1 = channel::after(ms(100));
-            let r2 = channel::after(ms(100));
+            let r1 = channel::after(ms(50));
+            let r2 = channel::after(ms(50));
 
             crossbeam::scope(|scope| {
                 scope.spawn(|| {
@@ -121,13 +121,13 @@ macro_rules! tests {
         #[test]
         fn recv_race() {
             select! {
-                recv(channel::after(ms(100))) => {}
-                recv(channel::after(ms(200))) => panic!(),
+                recv(channel::after(ms(50))) => {}
+                recv(channel::after(ms(100))) => panic!(),
             }
 
             select! {
-                recv(channel::after(ms(200))) => panic!(),
-                recv(channel::after(ms(100))) => {}
+                recv(channel::after(ms(100))) => panic!(),
+                recv(channel::after(ms(50))) => {}
             }
         }
 


### PR DESCRIPTION
They are too flaky on Travis because `thread::sleep` is not reliable enough. :(