### PR TITLE
Avoid panics when accessing thread locals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["channel", "mpmc", "select", "golang", "message"]
 categories = ["algorithms", "concurrency", "data-structures"]
 
 [dependencies]
-crossbeam-epoch = "0.5.0"
+crossbeam-epoch = "0.6.0"
 crossbeam-utils = "0.5.0"
 parking_lot = "0.6.3"
 rand = "0.5.3"

--- a/src/flavors/after.rs
+++ b/src/flavors/after.rs
@@ -10,6 +10,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use internal::channel::RecvNonblocking;
+use internal::context::Context;
 use internal::select::{Operation, SelectHandle, Token};
 use internal::utils;
 
@@ -223,7 +224,7 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn register(&self, _token: &mut Token, _oper: Operation) -> bool {
+    fn register(&self, _token: &mut Token, _oper: Operation, _cx: &Arc<Context>) -> bool {
         true
     }
 
@@ -231,7 +232,7 @@ impl SelectHandle for Channel {
     fn unregister(&self, _oper: Operation) {}
 
     #[inline]
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, _cx: &Arc<Context>) -> bool {
         self.try(token)
     }
 

--- a/src/flavors/array.rs
+++ b/src/flavors/array.rs
@@ -6,13 +6,14 @@ use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 use std::mem;
 use std::ptr;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Instant;
 
 use crossbeam_utils::CachePadded;
 
 use internal::channel::RecvNonblocking;
-use internal::context;
+use internal::context::{self, Context};
 use internal::select::{Operation, Select, SelectHandle, Token};
 use internal::utils::Backoff;
 use internal::waker::SyncWaker;
@@ -324,25 +325,27 @@ impl<T> Channel<T> {
                 }
             }
 
-            // Prepare for blocking until a receiver wakes us up.
-            context::current_reset();
-            self.senders.register(oper);
+            context::with_current(|cx| {
+                // Prepare for blocking until a receiver wakes us up.
+                cx.reset();
+                self.senders.register(oper, cx);
 
-            // Has the channel become ready just now?
-            if !self.is_full() {
-                let _ = context::current_try_select(Select::Aborted);
-            }
+                // Has the channel become ready just now?
+                if !self.is_full() {
+                    let _ = cx.try_select(Select::Aborted);
+                }
 
-            // Block the current thread.
-            let sel = context::current_wait_until(None);
+                // Block the current thread.
+                let sel = cx.wait_until(None);
 
-            match sel {
-                Select::Waiting | Select::Closed => unreachable!(),
-                Select::Aborted => {
-                    self.senders.unregister(oper).unwrap();
-                },
-                Select::Operation(_) => {}
-            }
+                match sel {
+                    Select::Waiting | Select::Closed => unreachable!(),
+                    Select::Aborted => {
+                        self.senders.unregister(oper).unwrap();
+                    },
+                    Select::Operation(_) => {}
+                }
+            })
         }
     }
 
@@ -364,26 +367,28 @@ impl<T> Channel<T> {
                 }
             }
 
-            // Prepare for blocking until a sender wakes us up.
-            context::current_reset();
-            self.receivers.register(oper);
+            context::with_current(|cx| {
+                // Prepare for blocking until a sender wakes us up.
+                cx.reset();
+                self.receivers.register(oper, cx);
 
-            // Has the channel become ready just now?
-            if !self.is_empty() || self.is_closed() {
-                let _ = context::current_try_select(Select::Aborted);
-            }
+                // Has the channel become ready just now?
+                if !self.is_empty() || self.is_closed() {
+                    let _ = cx.try_select(Select::Aborted);
+                }
 
-            // Block the current thread.
-            let sel = context::current_wait_until(None);
+                // Block the current thread.
+                let sel = cx.wait_until(None);
 
-            match sel {
-                Select::Waiting => unreachable!(),
-                Select::Aborted | Select::Closed => {
-                    self.receivers.unregister(oper).unwrap();
-                    // If the channel was closed, we still have to check for remaining messages.
-                },
-                Select::Operation(_) => {}
-            }
+                match sel {
+                    Select::Waiting => unreachable!(),
+                    Select::Aborted | Select::Closed => {
+                        self.receivers.unregister(oper).unwrap();
+                        // If the channel was closed, we still have to check for remaining messages.
+                    },
+                    Select::Operation(_) => {}
+                }
+            })
         }
     }
 
@@ -513,8 +518,8 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
         None
     }
 
-    fn register(&self, _token: &mut Token, oper: Operation) -> bool {
-        self.0.receivers.register(oper);
+    fn register(&self, _token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
+        self.0.receivers.register(oper, cx);
         self.0.is_empty() && !self.0.is_closed()
     }
 
@@ -522,7 +527,7 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
         self.0.receivers.unregister(oper);
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, _cx: &Arc<Context>) -> bool {
         self.0.start_recv(token, &mut Backoff::new())
     }
 
@@ -544,8 +549,8 @@ impl<'a, T> SelectHandle for Sender<'a, T> {
         None
     }
 
-    fn register(&self, _token: &mut Token, oper: Operation) -> bool {
-        self.0.senders.register(oper);
+    fn register(&self, _token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
+        self.0.senders.register(oper, cx);
         self.0.is_full()
     }
 
@@ -553,7 +558,7 @@ impl<'a, T> SelectHandle for Sender<'a, T> {
         self.0.senders.unregister(oper);
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, _cx: &Arc<Context>) -> bool {
         self.0.start_send(token, &mut Backoff::new())
     }
 

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -4,6 +4,7 @@ use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
 use std::ptr;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Instant;
 
@@ -11,7 +12,7 @@ use crossbeam_epoch::{self as epoch, Atomic, Guard, Owned};
 use crossbeam_utils::CachePadded;
 
 use internal::channel::RecvNonblocking;
-use internal::context;
+use internal::context::{self, Context};
 use internal::select::{Operation, Select, SelectHandle, Token};
 use internal::utils::Backoff;
 use internal::waker::SyncWaker;
@@ -269,7 +270,7 @@ impl<T> Channel<T> {
                         }
 
                         unsafe {
-                            guard.defer(move || head_ptr.into_owned());
+                            guard.defer_destroy(head_ptr);
                         }
                     }
 
@@ -332,25 +333,27 @@ impl<T> Channel<T> {
             }
 
             // Prepare for blocking until a sender wakes us up.
-            context::current_reset();
-            self.receivers.register(oper);
+            context::with_current(|cx| {
+                cx.reset();
+                self.receivers.register(oper, cx);
 
-            // Has the channel become ready just now?
-            if !self.is_empty() || self.is_closed() {
-                let _ = context::current_try_select(Select::Aborted);
-            }
+                // Has the channel become ready just now?
+                if !self.is_empty() || self.is_closed() {
+                    let _ = cx.try_select(Select::Aborted);
+                }
 
-            // Block the current thread.
-            let sel = context::current_wait_until(None);
+                // Block the current thread.
+                let sel = cx.wait_until(None);
 
-            match sel {
-                Select::Waiting => unreachable!(),
-                Select::Aborted | Select::Closed => {
-                    self.receivers.unregister(oper).unwrap();
-                    // If the channel was closed, we still have to check for remaining messages.
-                },
-                Select::Operation(_) => {},
-            }
+                match sel {
+                    Select::Waiting => unreachable!(),
+                    Select::Aborted | Select::Closed => {
+                        self.receivers.unregister(oper).unwrap();
+                        // If the channel was closed, we still have to check for remaining messages.
+                    },
+                    Select::Operation(_) => {},
+                }
+            })
         }
     }
 
@@ -466,8 +469,8 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
         None
     }
 
-    fn register(&self, _token: &mut Token, oper: Operation) -> bool {
-        self.0.receivers.register(oper);
+    fn register(&self, _token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
+        self.0.receivers.register(oper, cx);
         self.0.is_empty() && !self.0.is_closed()
     }
 
@@ -475,7 +478,7 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
         self.0.receivers.unregister(oper);
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, _cx: &Arc<Context>) -> bool {
         self.0.start_recv(token, &mut Backoff::new())
     }
 
@@ -497,13 +500,13 @@ impl<'a, T> SelectHandle for Sender<'a, T> {
         None
     }
 
-    fn register(&self, _token: &mut Token, _oper: Operation) -> bool {
+    fn register(&self, _token: &mut Token, _oper: Operation, _cx: &Arc<Context>) -> bool {
         false
     }
 
     fn unregister(&self, _oper: Operation) {}
 
-    fn accept(&self, _token: &mut Token) -> bool {
+    fn accept(&self, _token: &mut Token, _cx: &Arc<Context>) -> bool {
         true
     }
 

--- a/src/flavors/tick.rs
+++ b/src/flavors/tick.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 
 use internal::channel::RecvNonblocking;
+use internal::context::Context;
 use internal::select::{Operation, SelectHandle, Token};
 
 /// Result of a receive operation.
@@ -163,7 +164,7 @@ impl SelectHandle for Channel {
     }
 
     #[inline]
-    fn register(&self, _token: &mut Token, _oper: Operation) -> bool {
+    fn register(&self, _token: &mut Token, _oper: Operation, _cx: &Arc<Context>) -> bool {
         true
     }
 
@@ -171,7 +172,7 @@ impl SelectHandle for Channel {
     fn unregister(&self, _oper: Operation) {}
 
     #[inline]
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, _cx: &Arc<Context>) -> bool {
         self.try(token)
     }
 

--- a/src/flavors/zero.rs
+++ b/src/flavors/zero.rs
@@ -4,6 +4,7 @@
 
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Instant;
@@ -11,7 +12,7 @@ use std::time::Instant;
 use parking_lot::Mutex;
 
 use internal::channel::RecvNonblocking;
-use internal::context;
+use internal::context::{self, Context};
 use internal::select::{Operation, Select, SelectHandle, Token};
 use internal::utils::Backoff;
 use internal::waker::Waker;
@@ -116,49 +117,50 @@ impl<T> Channel<T> {
     fn start_send(&self, token: &mut Token, short_pause: bool) -> bool {
         let oper = Operation::hook(token);
 
-        {
-            let mut inner = self.inner.lock();
+        let mut inner = self.inner.lock();
 
-            // If there's a waiting receiver, pair up with it.
-            if let Some(operation) = inner.receivers.wake_one() {
-                token.zero = operation.packet;
-                return true;
-            }
-
-            if !short_pause {
-                return false;
-            }
-
-            // Register this send operation so that another receiver can pair up with it.
-            context::current_reset();
-            let packet = Box::into_raw(Packet::<T>::empty_on_heap());
-            inner.senders.register_with_packet(oper, packet as usize);
+        // If there's a waiting receiver, pair up with it.
+        if let Some(operation) = inner.receivers.wake_one() {
+            token.zero = operation.packet;
+            return true;
         }
 
-        // Yield to give receivers a chance to pair up with this operation.
-        thread::yield_now();
-
-        let sel = match context::current_try_select(Select::Aborted) {
-            Ok(()) => Select::Aborted,
-            Err(s) => s,
-        };
-
-        match sel {
-            Select::Waiting | Select::Closed => unreachable!(),
-            Select::Aborted => {
-                // Unregister and destroy the packet.
-                let operation = self.inner.lock().senders.unregister(oper).unwrap();
-                unsafe {
-                    drop(Box::from_raw(operation.packet as *mut Packet<T>));
-                }
-                false
-            },
-            Select::Operation(_) => {
-                // Success! A receiver has paired up with this operation.
-                token.zero = context::current_wait_packet();
-                true
-            },
+        if !short_pause {
+            return false;
         }
+
+        // Register this send operation so that another receiver can pair up with it.
+        let packet = Box::into_raw(Packet::<T>::empty_on_heap());
+        let mut inner = Some(inner);
+        context::with_current(move |cx| {
+            cx.reset();
+            inner.take().unwrap().senders.register_with_packet(oper, packet as usize, cx);
+
+            // Yield to give receivers a chance to pair up with this operation.
+            thread::yield_now();
+
+            let sel = match cx.try_select(Select::Aborted) {
+                Ok(()) => Select::Aborted,
+                Err(s) => s,
+            };
+
+            match sel {
+                Select::Waiting | Select::Closed => unreachable!(),
+                Select::Aborted => {
+                    // Unregister and destroy the packet.
+                    let operation = self.inner.lock().senders.unregister(oper).unwrap();
+                    unsafe {
+                        drop(Box::from_raw(operation.packet as *mut Packet<T>));
+                    }
+                    false
+                },
+                Select::Operation(_) => {
+                    // Success! A receiver has paired up with this operation.
+                    token.zero = cx.wait_packet();
+                    true
+                },
+            }
+        })
     }
 
     /// Writes a message into the packet.
@@ -171,63 +173,65 @@ impl<T> Channel<T> {
     /// Attempts to pair up with a sender.
     fn start_recv(&self, token: &mut Token, short_pause: bool) -> bool {
         let oper = Operation::hook(token);
-        {
-            let mut inner = self.inner.lock();
 
-            // If there's a waiting sender, pair up with it.
-            if let Some(operation) = inner.senders.wake_one() {
-                token.zero = operation.packet;
-                return true;
-            } else if inner.is_closed {
-                token.zero = 0;
-                return true;
-            }
+        let mut inner = self.inner.lock();
 
-            if !short_pause {
-                return false;
-            }
-
-            // Register this receive operation so that another sender can pair up with it.
-            context::current_reset();
-            let packet = Box::into_raw(Packet::<T>::empty_on_heap());
-            inner.receivers.register_with_packet(oper, packet as usize);
+        // If there's a waiting sender, pair up with it.
+        if let Some(operation) = inner.senders.wake_one() {
+            token.zero = operation.packet;
+            return true;
+        } else if inner.is_closed {
+            token.zero = 0;
+            return true;
         }
 
-        // Yield to give senders a chance to pair up with this operation.
-        thread::yield_now();
-
-        let sel = match context::current_try_select(Select::Aborted) {
-            Ok(()) => Select::Aborted,
-            Err(s) => s,
-        };
-
-        match sel {
-            Select::Waiting => unreachable!(),
-            Select::Aborted => {
-                // Unregister and destroy the packet.
-                let operation = self.inner.lock().receivers.unregister(oper).unwrap();
-                unsafe {
-                    drop(Box::from_raw(operation.packet as *mut Packet<T>));
-                }
-                false
-            },
-            Select::Closed => {
-                // Unregister and destroy the packet.
-                let operation = self.inner.lock().receivers.unregister(oper).unwrap();
-                unsafe {
-                    drop(Box::from_raw(operation.packet as *mut Packet<T>));
-                }
-
-                // All senders have just been dropped.
-                token.zero = 0;
-                true
-            },
-            Select::Operation(_) => {
-                // Success! A sender has paired up with this operation.
-                token.zero = context::current_wait_packet();
-                true
-            },
+        if !short_pause {
+            return false;
         }
+
+        // Register this receive operation so that another sender can pair up with it.
+        let packet = Box::into_raw(Packet::<T>::empty_on_heap());
+        let mut inner = Some(inner);
+        context::with_current(move |cx| {
+            cx.reset();
+            inner.take().unwrap().receivers.register_with_packet(oper, packet as usize, cx);
+
+            // Yield to give senders a chance to pair up with this operation.
+            thread::yield_now();
+
+            let sel = match cx.try_select(Select::Aborted) {
+                Ok(()) => Select::Aborted,
+                Err(s) => s,
+            };
+
+            match sel {
+                Select::Waiting => unreachable!(),
+                Select::Aborted => {
+                    // Unregister and destroy the packet.
+                    let operation = self.inner.lock().receivers.unregister(oper).unwrap();
+                    unsafe {
+                        drop(Box::from_raw(operation.packet as *mut Packet<T>));
+                    }
+                    false
+                },
+                Select::Closed => {
+                    // Unregister and destroy the packet.
+                    let operation = self.inner.lock().receivers.unregister(oper).unwrap();
+                    unsafe {
+                        drop(Box::from_raw(operation.packet as *mut Packet<T>));
+                    }
+
+                    // All senders have just been dropped.
+                    token.zero = 0;
+                    true
+                },
+                Select::Operation(_) => {
+                    // Success! A sender has paired up with this operation.
+                    token.zero = cx.wait_packet();
+                    true
+                },
+            }
+        })
     }
 
     /// Reads a message from the packet.
@@ -261,36 +265,39 @@ impl<T> Channel<T> {
         let token = &mut Token::default();
         let oper = Operation::hook(token);
         let packet;
-        {
-            let mut inner = self.inner.lock();
 
-            // If there's a waiting receiver, pair up with it.
-            if let Some(operation) = inner.receivers.wake_one() {
-                token.zero = operation.packet;
-                drop(inner);
-                unsafe { self.write(token, msg); }
-                return;
-            }
+        let mut inner = self.inner.lock();
 
-            // Prepare for blocking until a receiver wakes us up.
-            context::current_reset();
-            packet = Packet::message_on_stack(msg);
-            inner.senders.register_with_packet(
+        // If there's a waiting receiver, pair up with it.
+        if let Some(operation) = inner.receivers.wake_one() {
+            token.zero = operation.packet;
+            drop(inner);
+            unsafe { self.write(token, msg); }
+            return;
+        }
+
+        // Prepare for blocking until a receiver wakes us up.
+        packet = Packet::message_on_stack(msg);
+        let mut inner = Some(inner);
+        context::with_current(move |cx| {
+            cx.reset();
+            inner.take().unwrap().senders.register_with_packet(
                 oper,
                 &packet as *const Packet<T> as usize,
+                cx,
             );
-        }
 
-        // Block the current thread.
-        let sel = context::current_wait_until(None);
+            // Block the current thread.
+            let sel = cx.wait_until(None);
 
-        match sel {
-            Select::Waiting | Select::Aborted | Select::Closed => unreachable!(),
-            Select::Operation(_) => {
-                // Wait until the message is read, then drop the packet.
-                packet.wait_ready();
-            },
-        }
+            match sel {
+                Select::Waiting | Select::Aborted | Select::Closed => unreachable!(),
+                Select::Operation(_) => {
+                    // Wait until the message is read, then drop the packet.
+                    packet.wait_ready();
+                },
+            }
+        })
     }
 
     /// Receives a message from the channel.
@@ -298,44 +305,47 @@ impl<T> Channel<T> {
         let token = &mut Token::default();
         let oper = Operation::hook(token);
         let packet;
-        {
-            let mut inner = self.inner.lock();
 
-            // If there's a waiting sender, pair up with it.
-            if let Some(operation) = inner.senders.wake_one() {
-                token.zero = operation.packet;
-                drop(inner);
-                unsafe { return self.read(token); }
-            }
+        let mut inner = self.inner.lock();
 
-            if inner.is_closed {
-                return None;
-            }
+        // If there's a waiting sender, pair up with it.
+        if let Some(operation) = inner.senders.wake_one() {
+            token.zero = operation.packet;
+            drop(inner);
+            unsafe { return self.read(token); }
+        }
 
-            // Prepare for blocking until a sender wakes us up.
-            context::current_reset();
-            packet = Packet::<T>::empty_on_stack();
-            inner.receivers.register_with_packet(
+        if inner.is_closed {
+            return None;
+        }
+
+        // Prepare for blocking until a sender wakes us up.
+        packet = Packet::<T>::empty_on_stack();
+        let mut inner = Some(inner);
+        context::with_current(move |cx| {
+            cx.reset();
+            inner.take().unwrap().receivers.register_with_packet(
                 oper,
                 &packet as *const Packet<T> as usize,
+                cx,
             );
-        }
 
-        // Block the current thread.
-        let sel = context::current_wait_until(None);
+            // Block the current thread.
+            let sel = cx.wait_until(None);
 
-        match sel {
-            Select::Waiting | Select::Aborted => unreachable!(),
-            Select::Closed => {
-                self.inner.lock().receivers.unregister(oper).unwrap();
-                None
-            },
-            Select::Operation(_) => {
-                // Wait until the message is provided, then read it.
-                packet.wait_ready();
-                unsafe { Some(packet.msg.get().replace(None).unwrap()) }
-            },
-        }
+            match sel {
+                Select::Waiting | Select::Aborted => unreachable!(),
+                Select::Closed => {
+                    self.inner.lock().receivers.unregister(oper).unwrap();
+                    None
+                },
+                Select::Operation(_) => {
+                    // Wait until the message is provided, then read it.
+                    packet.wait_ready();
+                    unsafe { Some(packet.msg.get().replace(None).unwrap()) }
+                },
+            }
+        })
     }
 
     /// Attempts to receive a message without blocking.
@@ -408,11 +418,11 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
         None
     }
 
-    fn register(&self, _token: &mut Token, oper: Operation) -> bool {
+    fn register(&self, _token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
         let packet = Box::into_raw(Packet::<T>::empty_on_heap());
 
         let mut inner = self.0.inner.lock();
-        inner.receivers.register_with_packet(oper, packet as usize);
+        inner.receivers.register_with_packet(oper, packet as usize, cx);
         !inner.senders.can_wake_one() && !inner.is_closed
     }
 
@@ -424,8 +434,8 @@ impl<'a, T> SelectHandle for Receiver<'a, T> {
         }
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
-        token.zero = context::current_wait_packet();
+    fn accept(&self, token: &mut Token, cx: &Arc<Context>) -> bool {
+        token.zero = cx.wait_packet();
         true
     }
 
@@ -447,11 +457,11 @@ impl<'a, T> SelectHandle for Sender<'a, T> {
         None
     }
 
-    fn register(&self, _token: &mut Token, oper: Operation) -> bool {
+    fn register(&self, _token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
         let packet = Box::into_raw(Packet::<T>::empty_on_heap());
 
         let mut inner = self.0.inner.lock();
-        inner.senders.register_with_packet(oper, packet as usize);
+        inner.senders.register_with_packet(oper, packet as usize, cx);
         !inner.receivers.can_wake_one()
     }
 
@@ -463,8 +473,8 @@ impl<'a, T> SelectHandle for Sender<'a, T> {
         }
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
-        token.zero = context::current_wait_packet();
+    fn accept(&self, token: &mut Token, cx: &Arc<Context>) -> bool {
+        token.zero = cx.wait_packet();
         true
     }
 

--- a/src/internal/channel.rs
+++ b/src/internal/channel.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use flavors;
+use internal::context::Context;
 use internal::select::{Operation, SelectHandle, Token};
 
 /// A channel in the form of one of the different flavors.
@@ -753,11 +754,11 @@ impl<T> SelectHandle for Sender<T> {
         None
     }
 
-    fn register(&self, token: &mut Token, oper: Operation) -> bool {
+    fn register(&self, token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
         match &self.0.flavor {
-            ChannelFlavor::Array(chan) => chan.sender().register(token, oper),
-            ChannelFlavor::List(chan) => chan.sender().register(token, oper),
-            ChannelFlavor::Zero(chan) => chan.sender().register(token, oper),
+            ChannelFlavor::Array(chan) => chan.sender().register(token, oper, cx),
+            ChannelFlavor::List(chan) => chan.sender().register(token, oper, cx),
+            ChannelFlavor::Zero(chan) => chan.sender().register(token, oper, cx),
         }
     }
 
@@ -769,11 +770,11 @@ impl<T> SelectHandle for Sender<T> {
         }
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, cx: &Arc<Context>) -> bool {
         match &self.0.flavor {
-            ChannelFlavor::Array(chan) => chan.sender().accept(token),
-            ChannelFlavor::List(chan) => chan.sender().accept(token),
-            ChannelFlavor::Zero(chan) => chan.sender().accept(token),
+            ChannelFlavor::Array(chan) => chan.sender().accept(token, cx),
+            ChannelFlavor::List(chan) => chan.sender().accept(token, cx),
+            ChannelFlavor::Zero(chan) => chan.sender().accept(token, cx),
         }
     }
 
@@ -819,15 +820,15 @@ impl<T> SelectHandle for Receiver<T> {
         }
     }
 
-    fn register(&self, token: &mut Token, oper: Operation) -> bool {
+    fn register(&self, token: &mut Token, oper: Operation, cx: &Arc<Context>) -> bool {
         match &self.0 {
             ReceiverFlavor::Channel(arc) => match &arc.flavor {
-                ChannelFlavor::Array(chan) => chan.receiver().register(token, oper),
-                ChannelFlavor::List(chan) => chan.receiver().register(token, oper),
-                ChannelFlavor::Zero(chan) => chan.receiver().register(token, oper),
+                ChannelFlavor::Array(chan) => chan.receiver().register(token, oper, cx),
+                ChannelFlavor::List(chan) => chan.receiver().register(token, oper, cx),
+                ChannelFlavor::Zero(chan) => chan.receiver().register(token, oper, cx),
             },
-            ReceiverFlavor::After(chan) => chan.register(token, oper),
-            ReceiverFlavor::Tick(chan) => chan.register(token, oper),
+            ReceiverFlavor::After(chan) => chan.register(token, oper, cx),
+            ReceiverFlavor::Tick(chan) => chan.register(token, oper, cx),
         }
     }
 
@@ -843,15 +844,15 @@ impl<T> SelectHandle for Receiver<T> {
         }
     }
 
-    fn accept(&self, token: &mut Token) -> bool {
+    fn accept(&self, token: &mut Token, cx: &Arc<Context>) -> bool {
         match &self.0 {
             ReceiverFlavor::Channel(arc) => match &arc.flavor {
-                ChannelFlavor::Array(chan) => chan.receiver().accept(token),
-                ChannelFlavor::List(chan) => chan.receiver().accept(token),
-                ChannelFlavor::Zero(chan) => chan.receiver().accept(token),
+                ChannelFlavor::Array(chan) => chan.receiver().accept(token, cx),
+                ChannelFlavor::List(chan) => chan.receiver().accept(token, cx),
+                ChannelFlavor::Zero(chan) => chan.receiver().accept(token, cx),
             },
-            ReceiverFlavor::After(chan) => chan.accept(token),
-            ReceiverFlavor::Tick(chan) => chan.accept(token),
+            ReceiverFlavor::After(chan) => chan.accept(token, cx),
+            ReceiverFlavor::Tick(chan) => chan.accept(token, cx),
         }
     }
 

--- a/src/internal/waker.rs
+++ b/src/internal/waker.rs
@@ -46,15 +46,15 @@ impl Waker {
 
     /// Registers the current thread with an operation.
     #[inline]
-    pub fn register(&mut self, oper: Operation) {
-        self.register_with_packet(oper, 0);
+    pub fn register(&mut self, oper: Operation, cx: &Arc<Context>) {
+        self.register_with_packet(oper, 0, cx);
     }
 
     /// Registers the current thread with an operation and a packet.
     #[inline]
-    pub fn register_with_packet(&mut self, oper: Operation, packet: usize) {
+    pub fn register_with_packet(&mut self, oper: Operation, packet: usize, cx: &Arc<Context>) {
         self.entries.push_back(Entry {
-            context: context::current(),
+            context: cx.clone(),
             oper,
             packet,
         });
@@ -194,9 +194,9 @@ impl SyncWaker {
 
     /// Registers the current thread with an operation.
     #[inline]
-    pub fn register(&self, oper: Operation) {
+    pub fn register(&self, oper: Operation, cx: &Arc<Context>) {
         let mut inner = self.inner.lock();
-        inner.register(oper);
+        inner.register(oper, cx);
         self.len.store(inner.len(), Ordering::SeqCst);
     }
 

--- a/tests/thread_locals.rs
+++ b/tests/thread_locals.rs
@@ -1,0 +1,53 @@
+//! Tests that make sure accessing thread-locals while exiting the thread doesn't cause panics.
+
+#![deny(unsafe_code)]
+
+extern crate crossbeam;
+#[macro_use]
+extern crate crossbeam_channel as channel;
+
+use std::thread;
+use std::time::Duration;
+
+fn ms(ms: u64) -> Duration {
+    Duration::from_millis(ms)
+}
+
+#[test]
+fn use_while_exiting() {
+    struct Foo;
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            // A blocking operation after the thread-locals have been dropped. This will attempt to
+            // use the thread-locals and must not panic.
+            let (_s, r) = channel::unbounded::<()>();
+            select! {
+                recv(r) => {}
+                recv(channel::after(ms(100))) => {}
+            }
+        }
+    }
+
+    thread_local! {
+        static FOO: Foo = Foo;
+    }
+
+    let (s, r) = channel::unbounded::<()>();
+
+    crossbeam::scope(|scope| {
+        scope.spawn(|| {
+            // First initialize `FOO`, then the thread-locals related to crossbeam-channel and
+            // crossbeam-epoch.
+            FOO.with(|_| ());
+            r.recv().unwrap();
+            // At thread exit, the crossbeam-related thread-locals get dropped first and `FOO` is
+            // dropped last.
+        });
+
+        scope.spawn(|| {
+            thread::sleep(ms(100));
+            s.send(());
+        });
+    });
+}


### PR DESCRIPTION
This PR makes sure that channels can be used even while the TLS is tearing down.

cc https://github.com/servo/servo/pull/21325