### PR TITLE
Move the tail pointer forward instead of only spinning

### DIFF
--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -159,7 +159,7 @@ impl<T> Channel<T> {
             self.tail.block.compare_and_set(tail_ptr, e.current, Ordering::Release, guard);
             // Actually, drop of e.new will be called automatically...
             drop(e.new);
-        });
+        }).unwrap_or_default();
     }
 
     /// Writes a message into the channel.

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -153,10 +153,10 @@ impl<T> Channel<T> {
         // try to move the tail pointer forward
         tail.next.compare_and_set(Shared::null(), new, Ordering::Release, guard)
         .map(|shared| {
-            self.tail.block.compare_and_set(tail_ptr, shared, Ordering::Release, guard);
+            self.tail.block.compare_and_set(tail_ptr, shared, Ordering::Release, guard).unwrap_or_default();
         })
         .map_err(|e| {
-            self.tail.block.compare_and_set(tail_ptr, e.current, Ordering::Release, guard);
+            self.tail.block.compare_and_set(tail_ptr, e.current, Ordering::Release, guard).unwrap_or_default();
             // Actually, drop of e.new will be called automatically...
             drop(e.new);
         }).unwrap_or_default();

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -147,7 +147,7 @@ impl<T> Channel<T> {
         Sender(self)
     }
 
-    fn link_next_block<'g>(&self, tail_ptr: Shared<Block<T>>, tail: &'g Block<T>, index: usize, guard: &'g Guard) {
+    fn link_next_block<'g>(&self, tail_ptr: Shared<Block<T>>, tail: &Block<T>, index: usize, guard: &'g Guard) {
         let new = Owned::new(Block::new(index));
 
         // try to move the tail pointer forward


### PR DESCRIPTION
Hi, the unbounded mpmc channel is is especially fast!
It's based on inked list of queue blocks and very similar to [A Wait-free Queue as Fast as Fetch-and-Add](http://chaoran.me/assets/pdf/wfq-ppopp16.pdf) and [Fast Concurrent Queues for x86 Processors](https://www.cs.tau.ac.il/~mad/publications/ppopp2013-x86queues.pdf). The main difference is that the latter uses the "fetch_add" Instruction.

when Involving dependencies between writers, in the below codes(before tail.next.store(...)), while transfer to the next block, the unique writer will block other writers if It's slow. It is a small flaw in my opinion. :)
<pre><code>if offset + 1 == BLOCK_CAP {
    let new = Owned::new(Block::new(new_index)).into_shared(&guard);
    tail.next.store(new, Ordering::Release);
    self.tail.block.store(new, Ordering::Release);
}</pre></code>

I think let other writers to help move the tail pointer forward instead of only spinning is a better idea, maybe It's a little slower than "busy-waiting" in some realistic systems, but  it provides better scalability :)
