### PR TITLE
A wait-free write method except garbage collection

### DIFF
--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -159,7 +159,7 @@ impl<T> Channel<T> {
             self.tail.block.compare_and_set(tail_ptr, e.current, Ordering::Release, guard);
             // Actually, drop of e.new will be called automatically...
             drop(e.new);
-        });
+        }).unwrap_or_default();
     }
 
     /// Writes a message into the channel.

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -153,10 +153,10 @@ impl<T> Channel<T> {
         // try to move the tail pointer forward
         tail.next.compare_and_set(Shared::null(), new, Ordering::Release, guard)
         .map(|shared| {
-            self.tail.block.compare_and_set(tail_ptr, shared, Ordering::Release, guard);
+            self.tail.block.compare_and_set(tail_ptr, shared, Ordering::Release, guard).unwrap_or_default();
         })
         .map_err(|e| {
-            self.tail.block.compare_and_set(tail_ptr, e.current, Ordering::Release, guard);
+            self.tail.block.compare_and_set(tail_ptr, e.current, Ordering::Release, guard).unwrap_or_default();
             // Actually, drop of e.new will be called automatically...
             drop(e.new);
         }).unwrap_or_default();

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -167,50 +167,44 @@ impl<T> Channel<T> {
         let guard = epoch::pin();
         let backoff = &mut Backoff::new();
 
+		// If it happen to retrieve stale value, we can get the right index along the `next` filed
+        let mut tail_ptr = self.tail.block.load(Ordering::Acquire, &guard);
+        let mut tail = unsafe { tail_ptr.deref() };
+
+        // The tail_index is wanted slot, this line must be executed after retrieve the tail.
+        // 171 line happens-before 178 line,
+        // Otherwise, the tail's start_index may exceed tail_index...
+        // and we can't reach right block, it was a disaster.
+        let tail_index = self.tail.index.fetch_add(1, Ordering::Relaxed);
+
+        // loop just for link next block, not for compare_exchange_weak...
         loop {
-            // These two load operations don't have to be `SeqCst`. If they happen to retrieve
-            // stale values, the following CAS will fail or won't even be attempted.
-            let tail_ptr = self.tail.block.load(Ordering::Acquire, &guard);
-            let tail = unsafe { tail_ptr.deref() };
-            let tail_index = self.tail.index.load(Ordering::Relaxed);
 
-            // Calculate the index of the corresponding slot in the block.
+            // Calculate the index of the corresponding distance from this block's start.
             let offset = tail_index.wrapping_sub(tail.start_index);
-
-            // Advance the current index one slot forward.
-            let new_index = tail_index.wrapping_add(1);
 
             // If `tail_index` is pointing into `tail`...
             if offset < BLOCK_CAP {
-                // Try moving the tail index forward.
-                if self
-                    .tail
-                    .index
-                    .compare_exchange_weak(
-                        tail_index,
-                        new_index,
-                        Ordering::SeqCst,
-                        Ordering::Relaxed,
-                    )
-                    .is_ok()
-                {
-                    // If this was the last slot in the block, allocate a new block.
-                    if offset + 1 == BLOCK_CAP {
-                        self.link_next_block(tail_ptr, tail, new_index, &guard);
-                    }
-
-                    unsafe {
-                        let slot = tail.slots.get_unchecked(offset).get();
-                        (*slot).msg.get().write(ManuallyDrop::new(msg));
-                        (*slot).ready.store(true, Ordering::Release);
-                    }
-                    break;
-                } else {
-                    backoff.step();
+                // If this was the last slot in the block, allocate a new block.
+                if offset + 1 == BLOCK_CAP {
+                    self.link_next_block(tail_ptr, tail, tail.start_index + BLOCK_CAP, &guard);
                 }
+
+                unsafe {
+                    let slot = tail.slots.get_unchecked(offset).get();
+                    (*slot).msg.get().write(ManuallyDrop::new(msg));
+                    (*slot).ready.store(true, Ordering::Release);
+                }
+                break;
+                // Now, no longer need backoff.
+
             } else {
-                // we can help the writer("offset + 1 == BLOCK_CAP") to add next block instead of spinning.
-                self.link_next_block(tail_ptr, tail, tail_index, &guard);
+                // we can help to add next block ( next.start_index = tail.start_index + BLOCK_CAP ) instead of spinning.
+                self.link_next_block(tail_ptr, tail, tail.start_index + BLOCK_CAP, &guard);
+
+                // Just along the `next` field to get the right block.
+                tail_ptr = tail.next.load(Ordering::Acquire, &guard);
+                tail = unsafe { tail_ptr.deref() };
             }
         }
 

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -147,7 +147,7 @@ impl<T> Channel<T> {
         Sender(self)
     }
 
-    fn link_next_block<'g>(&self, tail_ptr: Shared<Block<T>>, tail: &'g Block<T>, index: usize, guard: &'g Guard) {
+    fn link_next_block<'g>(&self, tail_ptr: Shared<Block<T>>, tail: &Block<T>, index: usize, guard: &'g Guard) {
         let new = Owned::new(Block::new(index));
 
         // try to move the tail pointer forward


### PR DESCRIPTION
Just providing another concurrent write implementation:
- Catch the right index througth 'fetch_add' at the very beginning.
- Just walk along the next block, no longer need backoff, no retry for compare and set...

This wait-free write method provides a **stronger progress guarantee**, theoretically.
But, it doesn't as fast as the current one actually :(
If not, please ignore.


