### PR TITLE
Embed Block messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.26.0
+  - 1.28.0
 
 script:
   - export RUSTFLAGS="-D warnings"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Next, add this to your crate:
 extern crate crossbeam_channel;
 ```
 
-The minimum required Rust version is 1.26.
+The minimum required Rust version is 1.28.
 
 ## License
 

--- a/src/flavors/list.rs
+++ b/src/flavors/list.rs
@@ -94,7 +94,7 @@ impl<T> Block<T> {
         alloc::alloc(layout) as *mut Self
     }
 
-    /// Deallocate memory that a block with `cap` slots holds.
+    /// Deallocate memory that a block holds.
     unsafe fn dealloc(ptr: Shared<Block<T>>) {
         let ptr = ptr.as_raw() as *mut Block<T>;
         let layout = Self::create_layout((*ptr).cap);
@@ -504,7 +504,7 @@ impl<T> Drop for Channel<T> {
                 let offset = head_index.wrapping_sub(head.start_index);
 
                 let slot = head.slots.get_unchecked(offset);
-                ManuallyDrop::drop(&mut (*slot).msg.get().read());
+                ManuallyDrop::drop(&mut *(*slot).msg.get());
 
                 if offset + 1 == head.cap {
                     let next = head.next.load(Ordering::Relaxed, epoch::unprotected());


### PR DESCRIPTION
Closes #81 

This builds off https://github.com/crossbeam-rs/crossbeam-channel/pull/100, and reverts back to the use of `UnsafeCell` within `Slot<T>`.

There are a few things I would like to discuss in this PR:

- [x] I changed the naming of `slots` to `msgs`. I don't have a strong preference on naming, but found myself thinking of that field as messages anyways so I did it for clarity.
- [x] I am unsure if `msgs` needs to be type `UnsafeCell<Slot<T>>; 0]`. The type `[Slot<T>; 0]` still passes, and allows a few `get()`s to be removed. I see the importance of `msg` in `Slot<T>` being `UnsafeCell`, but it's not as clear in this situation.
- [x] There is a new `msg_count` field in `Block<T>`. Do we want to consider embedding `msg_count` in `start_index` and just do some bitwise operations to retrieve the respective values? It would decrease the memory size of a `Block<T>` but also limits the size that `start_index` can be (which will still be large).

Any other feedback is welcome!